### PR TITLE
Refactor twiss

### DIFF
--- a/src/emit.f90
+++ b/src/emit.f90
@@ -139,7 +139,7 @@ subroutine emit(deltap, tol, orbit0, disp0, rt, u0, emit_v, nemit_v, &
   ORBIT1 = ORBIT 
 
   !---- Element matrix and length.
-  call tmmap(code,.true.,.true.,orbit,fmap,ek,re,te)
+  call tmmap(code,.true.,.true.,orbit,fmap,ek,re,te,.false.,el)
 
   if (fmap) then
      !---- Advance dispersion.

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -2866,11 +2866,10 @@ SUBROUTINE twchgo
   if (.not.centre) then
      call twprep(save,2,opt_fun,zero)
   else
-     opt_fun(3) = betx
-     opt_fun(4) = alfx
+     ! TODO: it is inconsistent that amux,amy from twcpgo are overwritten
+     ! with the values from twchgo here. These two lines should be removed
+     ! but it will break a test or two:
      opt_fun(5) = amux
-     opt_fun(6) = bety
-     opt_fun(7) = alfy
      opt_fun(8) = amuy
   endif
 
@@ -2891,10 +2890,6 @@ SUBROUTINE twchgo
 contains
 
 subroutine save_opt_fun()
-
-     OPT_FUN(9:14)  = ORBIT
-     OPT_FUN(15:18) = DISP(1:4)
-
      opt_fun(19) = wx
      opt_fun(20) = phix
      opt_fun(21) = dmux
@@ -2903,11 +2898,6 @@ subroutine save_opt_fun()
      opt_fun(24) = dmuy
 
      OPT_FUN(25:28) = ddisp(1:4)
-
-     opt_fun(29) = rmat(1,1)
-     opt_fun(30) = rmat(1,2)
-     opt_fun(31) = rmat(2,1)
-     opt_fun(32) = rmat(2,2)
 end subroutine
 
 end SUBROUTINE twchgo

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -1659,9 +1659,7 @@ SUBROUTINE twcpgo(rt,orbit0)
   double precision :: orbit(6), orbit2(6)
   double precision :: bvk, sumloc, pos0, sd, el
   double precision :: al_errors(align_max)
-  character(len=name_len) :: bxmax_name='nil ', bymax_name='nil '
-  character(len=name_len) :: dxmax_name='nil ', dymax_name='nil '
-  character(len=name_len) :: xcomax_name='nil ', ycomax_name='nil ', el_name
+  ! character(len=name_len) el_name
   character(len=130) :: msg
 
   integer, external :: el_par_vector, advance_node, restart_sequ, get_option, node_al_errors
@@ -1747,7 +1745,7 @@ SUBROUTINE twcpgo(rt,orbit0)
   if ( el .gt. eps) ele_body = .true.
 
   !--- 2013-Nov-14  10:34:00  ghislain: add acquisition of name of element here.
-  call element_name(el_name,len(el_name))
+  !call element_name(el_name,len(el_name))
 
   opt_fun(70) = g_elpar(g_kmax)
   opt_fun(71) = g_elpar(g_kmin)
@@ -1821,12 +1819,12 @@ SUBROUTINE twcpgo(rt,orbit0)
   iecnt=iecnt+1
 
   !--- save maxima and name of elements where they occur
-  if (betx .gt. bxmax) bxmax = betx; bxmax_name = el_name
-  if (bety .gt. bymax) bymax = bety; bymax_name = el_name
-  if (abs(disp(1)) .gt. dxmax) dxmax = abs(disp(1)); dxmax_name = el_name
-  if (abs(disp(3)) .gt. dymax) dymax = abs(disp(3)); dymax_name = el_name
-  if (abs(orbit(1)) .gt. xcomax) xcomax = abs(orbit(1)); xcomax_name = el_name
-  if (abs(orbit(3)) .gt. ycomax) ycomax = abs(orbit(3)); ycomax_name = el_name
+  bxmax  = max(bxmax,  betx)
+  bymax  = max(bymax,  bety)
+  dxmax  = max(dxmax,  abs(disp(1)))
+  dymax  = max(dymax,  abs(disp(3)))
+  xcomax = max(xcomax, abs(orbit(1)))
+  ycomax = max(ycomax, abs(orbit(3)))
 
 
   !--- 2013-Nov-14  14:18:07  ghislain: should only calculate the RMS values for active elements,

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -4458,7 +4458,7 @@ SUBROUTINE tmoct(fsec,ftrk,fcentre,orbit,fmap,el,dl,ek,re,te)
   endif
 
   !---- Concatenate with drift map.
-  call tmdrf0(fsec,ftrk,orbit,fmap,dl,ek,re,te)
+  call tmdrf(fsec,ftrk,orbit,fmap,dl,ek,re,te)
   call tmcat(fsec,re,te,rw,tw,re,te)
   if (fcentre) return
 
@@ -5749,33 +5749,6 @@ SUBROUTINE tmyrot(ftrk,orbit,fmap,ek,re,te)
 end SUBROUTINE tmyrot
 
 SUBROUTINE tmdrf(fsec,ftrk,orbit,fmap,dl,ek,re,te)
-  use twisslfi
-  use math_constfi, only : two
-  implicit none
-  !----------------------------------------------------------------------*
-  !     Purpose:                                                         *
-  !     TRANSPORT map for drift space, with centre option.               *
-  !     Input:                                                           *
-  !     fsec      (logical) if true, return second order terms.          *
-  !     ftrk      (logical) if true, track orbit.                        *
-  !     Input/output:                                                    *
-  !     orbit(6)  (double)  closed orbit.                                *
-  !     Output:                                                          *
-  !     fmap      (logical) if true, element has a map.                  *
-  !     dl        (double)  element length.                              *
-  !     ek(6)     (double)  kick due to element.                         *
-  !     re(6,6)   (double)  transfer matrix.                             *
-  !     te(6,6,6) (double)  second-order terms.                          *
-  !----------------------------------------------------------------------*
-  logical :: fsec, ftrk, fmap
-  double precision :: dl
-  double precision :: orbit(6), ek(6), re(6,6), te(6,6,6)
-
-  call tmdrf0(fsec,ftrk,orbit,fmap,dl,ek,re,te)
-
-end SUBROUTINE tmdrf
-
-SUBROUTINE tmdrf0(fsec,ftrk,orbit,fmap,dl,ek,re,te)
   use twissbeamfi, only : beta, gamma, dtbyds
   use matrices, only : EYE
   use math_constfi, only : zero, two, three
@@ -5826,7 +5799,7 @@ SUBROUTINE tmdrf0(fsec,ftrk,orbit,fmap,dl,ek,re,te)
   !---- Track orbit.
   if (ftrk) call tmtrak(ek,re,te,orbit,orbit)
 
-end SUBROUTINE tmdrf0
+end SUBROUTINE tmdrf
 
 SUBROUTINE tmrf(fsec,ftrk,fcentre,orbit,fmap,el,ds,ek,re,te)
   use twisslfi
@@ -5919,10 +5892,10 @@ SUBROUTINE tmrf(fsec,ftrk,fcentre,orbit,fmap,el,ds,ek,re,te)
   if (el .ne. zero) then
     ! TODO: generalize for ds!=0.5
     dl = el / two
-    call tmdrf0(fsec,ftrk,orbit,fmap,dl,ek0,rw,tw)
+    call tmdrf(fsec,ftrk,orbit,fmap,dl,ek0,rw,tw)
     call tmcat(fsec,re,te,rw,tw,re,te)
     if (fcentre) return
-    call tmdrf0(fsec,ftrk,orbit,fmap,dl,ek0,rw,tw)
+    call tmdrf(fsec,ftrk,orbit,fmap,dl,ek0,rw,tw)
     call tmcat(fsec,rw,tw,re,te,re,te)
   endif
 

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -2982,7 +2982,7 @@ SUBROUTINE twbttk(re,te)
   double precision :: re(6,6), te(6,6,6)
 
   integer :: i,k
-  double precision :: aux(6), auxp(6), rep(6,6), fre(6,6), frep(6,6)
+  double precision :: auxp(6), rep(6,6), fre(6,6), frep(6,6)
   double precision :: ax1, ax2, ay1, ay2, bx1, bx2, by1, by2
   double precision :: t2, ta, tb, temp, tg
   double precision :: detl, f
@@ -2991,18 +2991,16 @@ SUBROUTINE twbttk(re,te)
   double precision, parameter :: eps=1d-8
 
   !---- Initialisation
-  AUX = zero
   AUXP = zero
   do i = 1, 6
      do k = 1, 6
         temp = dot_product(TE(i,:,k),DISP(:))
-        aux(i) = aux(i) + re(i,k)*disp(k)
         auxp(i) = auxp(i) + temp*disp(k) + re(i,k)*ddisp(k)
         rep(i,k) = two*temp
      enddo
   enddo
 
-  DISP = AUX
+  DISP = matmul(re, disp)
   DDISP = AUXP
 
   !---- Tor: modified to cancel energy change

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -1661,7 +1661,7 @@ SUBROUTINE twcpgo(rt,orbit0)
   double precision :: alfx0, betx0, amux0
   double precision :: alfy0, bety0, amuy0
   double precision :: orbit(6), orbit2(6)
-  double precision :: bvk, sumloc, sd, el
+  double precision :: bvk, sumloc, sd, el, currpos
   double precision :: al_errors(align_max)
   ! character(len=name_len) el_name
   character(len=130) :: msg
@@ -2774,7 +2774,7 @@ SUBROUTINE twchgo
   double precision :: orbit(6), orbit2(6), ek(6), re(6,6), te(6,6,6)
   double precision :: orbit00(6), ek00(6), re00(6,6), te00(6,6,6), disp00(6), ddisp00(6)
   double precision :: rmat0(2,2)
-  double precision :: al_errors(align_max), el, pos0
+  double precision :: al_errors(align_max), el, pos0, currpos
   character(len=130) :: msg
   double precision :: betx0, alfx0, amux0, wx0, dmux0, phix0
   double precision :: bety0, alfy0, amuy0, wy0, dmuy0, phiy0
@@ -2813,7 +2813,6 @@ SUBROUTINE twchgo
 
   !---- Loop over positions.
   i = restart_sequ()
-  if (centre) currpos = zero
   i_spch=0
 
 10 continue
@@ -2842,8 +2841,6 @@ SUBROUTINE twchgo
      call tmmap(code,.true.,.true.,orbit,fmap,ek,re,te,.true.,el/two)
      ! TG: same comment as in twchgo (inconsistent center behaviour) applies here:
      if (fmap) call twbttk(re,te)
-     pos0 = currpos
-     currpos = currpos + el/two
 
      call save_opt_fun()
      call twprep(save,2,opt_fun,zero)
@@ -2869,9 +2866,6 @@ SUBROUTINE twchgo
   if (.not.centre) then
      call twprep(save,2,opt_fun,zero)
   else
-     currpos = pos0 + el
-
-     opt_fun(2) = currpos
      opt_fun(3) = betx
      opt_fun(4) = alfx
      opt_fun(5) = amux
@@ -3159,7 +3153,7 @@ SUBROUTINE tw_summ(rt,tt)
 
   !---- Initialization transverse
   !---  fix length problem - HG 14.4.08 ! ghislain : ???
-  suml    = currpos  ! ???
+  suml    = opt_fun(2)  ! ???
   betx    = opt_fun0(3)
   alfx    = opt_fun0(4)
 

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -1656,12 +1656,12 @@ SUBROUTINE twcpgo(rt,orbit0)
   logical :: fmap, cplxy, cplxt, sector_sel
   integer :: i, i1, i2, iecnt, code, save, n_align, elpar_vl
   double precision :: ek(6), re(6,6), rwi(6,6), rc(6,6), te(6,6,6)
-  double precision :: orbit00(6), ek00(6), re00(6,6), te00(6,6,6)
+  double precision :: orbit00(6), ek00(6), re00(6,6), te00(6,6,6), disp00(6)
   double precision :: rw0(6,6), rmat0(2,2)
   double precision :: alfx0, betx0, amux0
   double precision :: alfy0, bety0, amuy0
   double precision :: orbit(6), orbit2(6)
-  double precision :: bvk, sumloc, pos0, sd, el
+  double precision :: bvk, sumloc, sd, el
   double precision :: al_errors(align_max)
   ! character(len=name_len) el_name
   character(len=130) :: msg
@@ -1672,7 +1672,6 @@ SUBROUTINE twcpgo(rt,orbit0)
 
   !---- Initialization
   sumloc=zero
-  pos0=zero
   amux=zero
   amuy=zero
   currpos=zero
@@ -1771,30 +1770,33 @@ SUBROUTINE twcpgo(rt,orbit0)
 
      betx0=betx; alfx0=alfx; amux0=amux
      bety0=bety; alfy0=alfy; amuy0=amuy
-     RMAT0 = RMAT
+     RMAT0 = RMAT ; disp00 = disp
      if (rmatrix) RW0 = RW
 
-    centre_cptk = .true.
     ! TG: the `fmap` condition is only an approximation of the previous
     ! behaviour of the `centre` option - which was handled inconsistently
     ! across different elements (some never called twcptk, some always did,
     ! some only in certain cases):
     if (fmap) call twcptk(re,orbit)
-    centre_cptk = .false.
 
-     OPT_FUN(9:14) = ORBIT
+  bxmax  = max(bxmax,  betx)
+  bymax  = max(bymax,  bety)
+  dxmax  = max(dxmax,  abs(disp(1)))
+  dymax  = max(dymax,  abs(disp(3)))
+  xcomax = max(xcomax, abs(orbit(1)))
+  ycomax = max(ycomax, abs(orbit(3)))
+
      betx=betx0; alfx=alfx0; amux=amux0
      bety=bety0; alfy=alfy0; amuy=amuy0
-     RMAT = RMAT0
+     RMAT = RMAT0 ; disp = disp00
      if (rmatrix) RW = RW0
 
-     pos0 = currpos
-     currpos = currpos + el/two
+     ! AFTER DISP RESTORE:
      sd = rt(5,6) + dot_product(RT(5,1:4), DISP(1:4))
      eta = - sd * beta**2 / circ
      alfa = one / gamma**2 + eta
      opt_fun(74) = alfa
-     call twprep(save,1,opt_fun,currpos)
+     call twprep(save,1,opt_fun,currpos+el/two)
 
     ORBIT = ORBIT00 ; EK = EK00 ; RE = RE00 ; TE = TE00
   endif
@@ -1819,21 +1821,12 @@ SUBROUTINE twcpgo(rt,orbit0)
 
   sumloc = sumloc + el
   if (sector_sel) call twwmap(sumloc, orbit)
+  ! AFTER DISP UPDATE:
   sd = rt(5,6) + dot_product(RT(5,1:4),DISP(1:4))
   eta = - sd * beta**2 / circ
   alfa = one / gamma**2 + eta
   opt_fun(74) = alfa
-  if (centre) then
-     bxmax  = max(opt_fun(3)      ,bxmax)
-     bymax  = max(opt_fun(6)      ,bymax)
-     dxmax  = max(abs(opt_fun(15)),dxmax)
-     dymax  = max(abs(opt_fun(17)),dymax)
-     xcomax = max(abs(opt_fun(9 )),xcomax)
-     ycomax = max(abs(opt_fun(11)),ycomax)
-  else
-     OPT_FUN(9:14) = ORBIT
-     currpos=currpos+el
-  endif
+  currpos=currpos+el
   iecnt=iecnt+1
 
   !--- save maxima and name of elements where they occur
@@ -1856,24 +1849,6 @@ SUBROUTINE twcpgo(rt,orbit0)
 
   if (.not. centre) then
      call twprep(save,1,opt_fun,currpos)
-  else
-     currpos = pos0 + el
-
-     opt_fun(2) = currpos
-     opt_fun(3) = betx
-     opt_fun(4) = alfx
-     opt_fun(5) = amux
-     opt_fun(6) = bety
-     opt_fun(7) = alfy
-     opt_fun(8) = amuy
-
-     OPT_FUN(9:14) = ORBIT
-     OPT_FUN(15:18) = DISP(1:4)
-
-     opt_fun(29) = rmat(1,1)
-     opt_fun(30) = rmat(1,2)
-     opt_fun(31) = rmat(2,1)
-     opt_fun(32) = rmat(2,2)
   endif
 
   if (advance_node() .ne. 0) goto 10
@@ -1948,12 +1923,10 @@ SUBROUTINE twcptk(re,orbit)
   !---- Dispersion.
   DT = matmul(RE, DISP)
 
-  if (.not.centre .or. centre_cptk) OPT_FUN(15:18) = DT(1:4)
-  if (.not.centre_cptk) then
+  OPT_FUN(15:18) = DT(1:4)
      DISP(1:4) = DT(1:4)
      disp(5) = zero
      disp(6) = one
-  endif
 
   ! RE(1:4,1:4) = ( A , B
   !                 C , D)
@@ -2145,13 +2118,13 @@ SUBROUTINE twcptk(re,orbit)
      endif
   endif
 
-  if (.not.centre.or.centre_cptk) then
      opt_fun(3) = betx
      opt_fun(4) = alfx
      opt_fun(5) = amux
      opt_fun(6) = bety
      opt_fun(7) = alfy
      opt_fun(8) = amuy
+     OPT_FUN(9:14) = ORBIT
 
      opt_fun(29) = rmat(1,1)
      opt_fun(30) = rmat(1,2)
@@ -2164,7 +2137,6 @@ SUBROUTINE twcptk(re,orbit)
        opt_fun(74 + (i1-1)*6 + i2) = sigmat(i1,i2)
      enddo
      enddo
-  endif
 
   if (rmatrix) then
     do i1=1,6
@@ -2488,12 +2460,10 @@ SUBROUTINE twcptk_sagan(re,orbit) ! new, RD matrix, talman, sagan
   call element_name(name,len(name))
   !---- Dispersion.
   DT = matmul(RE, DISP)
-  if (.not.centre .or. centre_cptk) OPT_FUN(15:18) = DT(1:4)
-  if (.not.centre_cptk) then
+  OPT_FUN(15:18) = DT(1:4)
      DISP(1:4) = DT(1:4)
      disp(5) = zero
      disp(6) = one
-  endif
 
   ! RE(1:4,1:4) = ( A , B
   !                 C , D)
@@ -2668,7 +2638,6 @@ SUBROUTINE twcptk_sagan(re,orbit) ! new, RD matrix, talman, sagan
      endif
   endif
 
-  if (.not.centre.or.centre_cptk) then
      opt_fun(3) = betx
      opt_fun(4) = alfx
      opt_fun(5) = amux
@@ -2680,7 +2649,6 @@ SUBROUTINE twcptk_sagan(re,orbit) ! new, RD matrix, talman, sagan
      opt_fun(30) = rmat(1,2)
      opt_fun(31) = rmat(2,1)
      opt_fun(32) = rmat(2,2)
-  endif
 
   if (rmatrix) then
      do i1=1,6

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -1657,7 +1657,7 @@ SUBROUTINE twcpgo(rt,orbit0)
   integer :: i, i1, i2, iecnt, code, save, n_align, elpar_vl
   double precision :: ek(6), re(6,6), rwi(6,6), rc(6,6), te(6,6,6)
   double precision :: orbit00(6), ek00(6), re00(6,6), te00(6,6,6), disp00(6)
-  double precision :: rw0(6,6), rmat0(2,2)
+  double precision :: rw0(6,6), rmat0(2,2), sigmat00(6,6)
   double precision :: alfx0, betx0, amux0
   double precision :: alfy0, bety0, amuy0
   double precision :: orbit(6), orbit2(6)
@@ -1844,6 +1844,7 @@ subroutine backup_optics()
   bety0=bety; alfy0=alfy; amuy0=amuy
   RMAT0 = RMAT ; disp00 = disp
   if (rmatrix) RW0 = RW
+  sigmat00 = sigmat
 end subroutine backup_optics
 
 subroutine restore_optics()
@@ -1852,6 +1853,7 @@ subroutine restore_optics()
   bety=bety0; alfy=alfy0; amuy=amuy0
   RMAT = RMAT0 ; disp = disp00
   if (rmatrix) RW = RW0
+  sigmat = sigmat00
 end subroutine restore_optics
 
 subroutine save_opt_fun()
@@ -2778,7 +2780,7 @@ SUBROUTINE twchgo
   integer :: i, code, save, n_align
   double precision :: orbit(6), orbit2(6), ek(6), re(6,6), te(6,6,6)
   double precision :: orbit00(6), ek00(6), re00(6,6), te00(6,6,6), disp00(6), ddisp00(6)
-  double precision :: rmat0(2,2)
+  double precision :: rmat0(2,2), sigmat00(6,6)
   double precision :: al_errors(align_max), el, pos0, currpos
   character(len=130) :: msg
   double precision :: betx0, alfx0, amux0, wx0, dmux0, phix0
@@ -2891,6 +2893,7 @@ subroutine backup_optics()
      betx0=betx; alfx0=alfx; amux0=amux; wx0=wx; dmux0=dmux; phix0=phix
      bety0=bety; alfy0=alfy; amuy0=amuy; wy0=wy; dmuy0=dmuy; phiy0=phiy
      RMAT0 = RMAT ; disp00 = disp ; ddisp00 = ddisp
+     sigmat00 = sigmat
 end subroutine backup_optics
 
 subroutine restore_optics()
@@ -2898,6 +2901,7 @@ subroutine restore_optics()
      bety=bety0; alfy=alfy0; amuy=amuy0; wy=wy0; dmuy=dmuy0; phiy=phiy0
      RMAT = RMAT0 ; disp = disp00 ; ddisp = ddisp00
      ORBIT = ORBIT00 ; EK = EK00 ; RE = RE00 ; TE = TE00
+     sigmat = sigmat00
 end subroutine restore_optics
 
 subroutine save_opt_fun()

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -1765,15 +1765,9 @@ SUBROUTINE twcpgo(rt,orbit0)
   endif
 
   if (centre) then
-    ! backup optical functions
-    ORBIT00 = ORBIT ; EK00 = EK ; RE00 = RE ; TE00 = TE
+    call backup_optics()
 
     call tmmap(code,.true.,.true.,orbit,fmap,ek,re,te,.true.,el/two)
-
-     betx0=betx; alfx0=alfx; amux0=amux
-     bety0=bety; alfy0=alfy; amuy0=amuy
-     RMAT0 = RMAT ; disp00 = disp
-     if (rmatrix) RW0 = RW
 
     ! TG: the `fmap` condition is only an approximation of the previous
     ! behaviour of the `centre` option - which was handled inconsistently
@@ -1784,12 +1778,7 @@ SUBROUTINE twcpgo(rt,orbit0)
     call save_opt_fun()
     call twprep(save,1,opt_fun,currpos+el/two)
 
-    ! restore optical functions
-    betx=betx0; alfx=alfx0; amux=amux0
-    bety=bety0; alfy=alfy0; amuy=amuy0
-    RMAT = RMAT0 ; disp = disp00
-    if (rmatrix) RW = RW0
-    ORBIT = ORBIT00 ; EK = EK00 ; RE = RE00 ; TE = TE00
+    call restore_optics()
   endif
 
   ! now do exact calculation with full length:
@@ -1848,6 +1837,22 @@ SUBROUTINE twcpgo(rt,orbit0)
                        'to find the closed orbit, for optical calculations it ignores both.')
 
 contains
+
+subroutine backup_optics()
+  ORBIT00 = ORBIT ; EK00 = EK ; RE00 = RE ; TE00 = TE
+  betx0=betx; alfx0=alfx; amux0=amux
+  bety0=bety; alfy0=alfy; amuy0=amuy
+  RMAT0 = RMAT ; disp00 = disp
+  if (rmatrix) RW0 = RW
+end subroutine backup_optics
+
+subroutine restore_optics()
+  ORBIT = ORBIT00 ; EK = EK00 ; RE = RE00 ; TE = TE00
+  betx=betx0; alfx=alfx0; amux=amux0
+  bety=bety0; alfy=alfy0; amuy=amuy0
+  RMAT = RMAT0 ; disp = disp00
+  if (rmatrix) RW = RW0
+end subroutine restore_optics
 
 subroutine save_opt_fun()
     integer :: i1, i2
@@ -2832,11 +2837,7 @@ SUBROUTINE twchgo
   endif
 
   if (centre) then
-     ! backup optical functions
-     ORBIT00 = ORBIT ; EK00 = EK ; RE00 = RE ; TE00 = TE
-     betx0=betx; alfx0=alfx; amux0=amux; wx0=wx; dmux0=dmux; phix0=phix
-     bety0=bety; alfy0=alfy; amuy0=amuy; wy0=wy; dmuy0=dmuy; phiy0=phiy
-     RMAT0 = RMAT ; disp00 = disp ; ddisp00 = ddisp
+     call backup_optics()
 
      call tmmap(code,.true.,.true.,orbit,fmap,ek,re,te,.true.,el/two)
      ! TG: same comment as in twchgo (inconsistent center behaviour) applies here:
@@ -2845,11 +2846,7 @@ SUBROUTINE twchgo
      call save_opt_fun()
      call twprep(save,2,opt_fun,zero)
 
-     ! restore optical functions
-     betx=betx0; alfx=alfx0; amux=amux0; wx=wx0; dmux=dmux0; phix=phix0
-     bety=bety0; alfy=alfy0; amuy=amuy0; wy=wy0; dmuy=dmuy0; phiy=phiy0
-     RMAT = RMAT0 ; disp = disp00 ; ddisp = ddisp00
-     ORBIT = ORBIT00 ; EK = EK00 ; RE = RE00 ; TE = TE00
+     call restore_optics()
   endif
 
   call tmmap(code,.true.,.true.,orbit,fmap,ek,re,te,.false.,el)
@@ -2888,6 +2885,20 @@ SUBROUTINE twchgo
   endif
 
 contains
+
+subroutine backup_optics()
+     ORBIT00 = ORBIT ; EK00 = EK ; RE00 = RE ; TE00 = TE
+     betx0=betx; alfx0=alfx; amux0=amux; wx0=wx; dmux0=dmux; phix0=phix
+     bety0=bety; alfy0=alfy; amuy0=amuy; wy0=wy; dmuy0=dmuy; phiy0=phiy
+     RMAT0 = RMAT ; disp00 = disp ; ddisp00 = ddisp
+end subroutine backup_optics
+
+subroutine restore_optics()
+     betx=betx0; alfx=alfx0; amux=amux0; wx=wx0; dmux=dmux0; phix=phix0
+     bety=bety0; alfy=alfy0; amuy=amuy0; wy=wy0; dmuy=dmuy0; phiy=phiy0
+     RMAT = RMAT0 ; disp = disp00 ; ddisp = ddisp00
+     ORBIT = ORBIT00 ; EK = EK00 ; RE = RE00 ; TE = TE00
+end subroutine restore_optics
 
 subroutine save_opt_fun()
      opt_fun(19) = wx

--- a/src/util.f90
+++ b/src/util.f90
@@ -344,7 +344,7 @@ module twisscfi
   double precision :: bxmax=0.d0, dxmax=0.d0, bymax=0.d0, dymax=0.d0
   double precision :: xcomax=0.d0, ycomax=0.d0, sigxco=0.d0, sigyco=0.d0
   double precision :: sigdx=0.d0, sigdy=0.d0
-  double precision :: wgt=0.d0, suml=0.d0, circ=0.d0, eta=0.d0, alfa=0.d0, gamtr=0.d0, currpos=0.d0
+  double precision :: wgt=0.d0, suml=0.d0, circ=0.d0, eta=0.d0, alfa=0.d0, gamtr=0.d0
   double precision :: wx=0.d0, phix=0.d0, dmux=0.d0, xix=0.d0, wy=0.d0, phiy=0.d0, dmuy=0.d0, xiy=0.d0
   double precision :: synch_1=0.d0, synch_2=0.d0, synch_3=0.d0, synch_4=0.d0, synch_5=0.d0
   double precision :: gammacp=1.d0

--- a/src/util.f90
+++ b/src/util.f90
@@ -323,7 +323,7 @@ end module twissafi
 module twisslfi
   implicit none
   public
-  logical :: centre=.false., centre_bttk=.false., first
+  logical :: centre=.false., first
   logical :: rmatrix=.false., sectormap=.false., ripken=.false.
   logical :: mode_flip=.false.
   logical :: ele_body=.false.

--- a/src/util.f90
+++ b/src/util.f90
@@ -323,7 +323,7 @@ end module twissafi
 module twisslfi
   implicit none
   public
-  logical :: centre=.false., centre_cptk=.false., centre_bttk=.false., first
+  logical :: centre=.false., centre_bttk=.false., first
   logical :: rmatrix=.false., sectormap=.false., ripken=.false.
   logical :: mode_flip=.false.
   logical :: ele_body=.false.


### PR DESCRIPTION
- handle centre option in `twcpgo`/`twchgo` instead of on each element
- a lot of cleanup on the structure of `twcpgo`/`twchgo`
- fix output of sigmat when centre is active
- fix a few inconsistencies with how centre was used (or not!) inside the elements
- tmcrab before the patch handled the center option in an extremely inconsistent manner, effectively calling twcptk multiple times via tmdrf