### PR TITLE
Implement matching at intermediate positions

### DIFF
--- a/src/mad_const.c
+++ b/src/mad_const.c
@@ -270,6 +270,9 @@ next_constraint(char* name, int* name_l, int* type, double* value,
     *weight = c_c->weight;
 
     if (c_c->n_pos == 0) {
+      // (in order to move constraint evaluation for "slow matching" to be
+      // during the twiss call –and hence make the slow option work with
+      // interpolation– we need to fuse `twchgo` and `twcpgo` first)
       string_from_table_row("twiss ", "name ", pos, node_name);
       double_from_table_row("twiss ",  name,   pos, val);
     }
@@ -411,7 +414,7 @@ next_global(char* name, int* name_l, int* type, double* value, double* c_min, do
 }
 
 void
-update_node_constraints(struct node* c_node, struct constraint_list* cl)
+update_node_constraints(struct node* c_node, struct constraint_list* cl, int index)
 {
   int i, j, k;
   k = 1; set_option("match_local", &k); /* flag */
@@ -421,11 +424,11 @@ update_node_constraints(struct node* c_node, struct constraint_list* cl)
     // copy constraint, so it can hold individual `evaluated` value (we could
     // do with a smaller data structure, but let's do it like this for now).
     struct constraint* c_new = clone_constraint(cl->constraints[j]);
-
+    c_new->index = index;
     for (i = 0; i < c_node->cl->curr; i++)
     {
       struct constraint* c_old = c_node->cl->constraints[i];
-      if (strcmp(c_new->name, c_old->name) == 0) {
+      if (c_old->index == index && strcmp(c_new->name, c_old->name) == 0) {
         c_node->cl->constraints[i] = c_new;
         break;
       }

--- a/src/mad_const.h
+++ b/src/mad_const.h
@@ -16,7 +16,7 @@ struct constraint /* contains one constraint */
                                 /* 3 both 1 + 2 */
                                 /* 4 value */
   int stamp;
-  int n_pos;
+  int n_pos, index;
   double value, c_min, c_max, weight, evaluated;
   struct expression *ex_value, *ex_c_min, *ex_c_max;
 };
@@ -42,7 +42,7 @@ struct constraint_list* delete_constraint_list(struct constraint_list*);
 
 void fill_constraint_list(int type, struct command*, struct constraint_list*);
 void update_sequ_constraints(struct sequence*, struct constraint_list*);
-void update_node_constraints(struct node*, struct constraint_list*);
+void update_node_constraints(struct node*, struct constraint_list*, int index);
 
 int  constraint_name(char* name, int* name_l, int* index);
 int  next_constr_namepos(char* name);

--- a/src/mad_dict.c
+++ b/src/mad_dict.c
@@ -2620,6 +2620,7 @@ const char *const_command_def =
 "name    = [s, none, none], "
 "weight   = [r, 1.0], "
 "range    = [s, #s/#e, none], "
+"iindex   = [r, -1, -1], "
 "class    = [s, none, none], "
 "pattern  = [s, any, none], "
 "betx     = [c, 0], alfx     = [c, 0], mux      = [c, 0], "

--- a/src/mad_match.c
+++ b/src/mad_match.c
@@ -313,6 +313,16 @@ match_cell(struct in_cmd* cmd)
 }
 #endif
 
+// if negative, cycle at high boundary and clamp in interval [lo, hi)
+static int
+cclamp(int num, int lo, int hi)
+{
+  if (num <   0) num += hi;
+  if (num <  lo) num = lo;
+  if (num >= hi) num = hi-1;
+  return num;
+}
+
 static void
 match_constraint(struct in_cmd* cmd)
 {
@@ -328,12 +338,16 @@ match_constraint(struct in_cmd* cmd)
   }
   else
   { /* old match */
-    // TODO: use all sequences!
+    double index = command_par_value("iindex", cmd->clone);
+
     comm_constraints->curr=0;
     fill_constraint_list(1, cmd->clone, comm_constraints);
     struct select_iter* it = start_iter_select(cmd->clone, match_sequs, NULL);
+
     while (fetch_node_select(it, &c_node, NULL)) {
-      update_node_constraints(c_node, comm_constraints);
+      int num_slice = c_node->interp_at ? c_node->interp_at->curr : 1;
+      int x = cclamp(index, 0, num_slice);
+      update_node_constraints(c_node, comm_constraints, x);
     }
   }
 }

--- a/src/mad_twiss.c
+++ b/src/mad_twiss.c
@@ -565,11 +565,13 @@ set_twiss_deltas(struct command* comm)
 // public interface
 
 void
-copy_twiss_data(double* twiss_data, int* offset, int* nval)
+copy_twiss_data(double* twiss_data, int* offset, int* nval, int* interp_index)
 {
   if (!current_node->cl) return;
   for (int i = 0; i < current_node->cl->curr; ++i) {
     struct constraint* c = current_node->cl->constraints[i];
+    if (c->index != *interp_index-1)
+      continue;
     int n_pos = c->n_pos - 1;
     if (n_pos >= *offset && n_pos < *offset + *nval)
       c->evaluated = twiss_data[n_pos];

--- a/src/mad_twiss.h
+++ b/src/mad_twiss.h
@@ -15,7 +15,7 @@ void  store_savebeta(struct in_cmd*);
 int   twiss_input(struct command*);
 
 void  get_disp0(double* disp);
-void  copy_twiss_data(double* twiss_data, int* offset, int* nval);
+void  copy_twiss_data(double* twiss_data, int* offset, int* nval, int* interp_index);
 void  complete_twiss_table(struct table*);
 int   embedded_twiss(void);
 

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -374,7 +374,7 @@ SUBROUTINE twinifun(opt_fun0,rt)
 
 end SUBROUTINE twinifun
 
-SUBROUTINE twprep(save,case,opt_fun,position)
+SUBROUTINE twprep(save,case,opt_fun,position,ii)
   use twissafi
   use twisslfi
   use twissotmfi
@@ -387,11 +387,12 @@ SUBROUTINE twprep(save,case,opt_fun,position)
   !     Input:                                                           *
   !     case        (integer) =1 fill from twcpgo; =2 fill from twchgo   *
   !     position    (double)  end position of element                    *
+  !     ii          (integer) index of interpolated segment
   !     Input/output:                                                    *
   !     opt_fun(fundim) (double) optical values:                         *
   !     betx,alfx,amux,bety,alfy,amuy, etc.                              *
   !----------------------------------------------------------------------*
-  integer :: save, case
+  integer :: save, case, ii
   double precision :: opt_fun(*), position
 
   integer :: i
@@ -403,7 +404,7 @@ SUBROUTINE twprep(save,case,opt_fun,position)
      opt5 = opt_fun(5) ; opt_fun(5) = opt_fun(5) / twopi
      opt8 = opt_fun(8) ; opt_fun(8) = opt_fun(8) / twopi
      if (save .ne. 0) call twfill(case,opt_fun,position)
-     if (match_is_on) call copy_twiss_data(opt_fun, 0, 110)
+     if (match_is_on) call copy_twiss_data(opt_fun, 0, 110, ii)
      opt_fun(5) = opt5
      opt_fun(8) = opt8
 
@@ -414,7 +415,7 @@ SUBROUTINE twprep(save,case,opt_fun,position)
      opt23 = opt_fun(23) ; opt_fun(23) = opt_fun(23) / twopi
      opt24 = opt_fun(24) ; opt_fun(24) = opt_fun(24) / twopi
      if (save .ne. 0) call twfill(case,opt_fun,position)
-     if (match_is_on) call copy_twiss_data(opt_fun, 18, 10)! fill 10 values starting with wx
+     if (match_is_on) call copy_twiss_data(opt_fun, 18, 10, ii)! fill 10 values starting with wx
      opt_fun(20) = opt20
      opt_fun(21) = opt21
      opt_fun(23) = opt23
@@ -1798,7 +1799,7 @@ subroutine track_one_element(el, fexit)
     if (fmap) call twcptk(re,orbit)
 
     call save_opt_fun()
-    call twprep(save,1,opt_fun,currpos+el/two)
+    call twprep(save,1,opt_fun,currpos+el/two,i)
 
     call restore_optics()
   endif
@@ -1838,7 +1839,7 @@ subroutine track_one_element(el, fexit)
 
   call save_opt_fun()
   if (fexit) then
-     call twprep(save,1,opt_fun,currpos)
+     call twprep(save,1,opt_fun,currpos,i)
   endif
 end subroutine track_one_element
 
@@ -2888,7 +2889,7 @@ subroutine track_one_element(el, fexit)
      if (fmap) call twbttk(re,te)
 
      call save_opt_fun()
-     call twprep(save,2,opt_fun,zero)
+     call twprep(save,2,opt_fun,zero,i)
 
      call restore_optics()
   endif
@@ -2909,7 +2910,7 @@ subroutine track_one_element(el, fexit)
 
   call save_opt_fun()
   if (.not.centre) then
-     call twprep(save,2,opt_fun,zero)
+     call twprep(save,2,opt_fun,zero,i)
   else
      ! TODO: it is inconsistent that amux,amy from twcpgo are overwritten
      ! with the values from twchgo here. These two lines should be removed


### PR DESCRIPTION
Currently works only when not using slow option. Fusing `twchgo` and `twcpgo` will be a precondition to make it work for slow option as well.

Note that this uses an additional argument `iindex` on the constraint to select for which interpolated slice the constraint should apply. I did not yet document this in case a cleaner solution is desired or if we should wait for it to work with slow.

I can adjust/patch as needed.