### PR TITLE
Coverage ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ numdiff-*-*
 numdiff32
 numdiff64
 
+# Coverage
+*.gcda
+*.gcno
+*.gcov
+
 # GC build:
 libs/gc/**/*.log
 libs/gc/**/*.lo

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,15 @@
 # Build/test script
 # ----------------------------------------
 
-language: c
+language: cpp
+compiler:
+  - gcc
+
+before_install:
+  - pip install --user cpp-coveralls
 
 install:
-  - make madx-linux64-gnu
+  - make madx-linux64-gnu COVERAGE=yes
   - make numdiff-linux64-gnu
 
 script:
@@ -17,6 +22,8 @@ script:
     NUM_FAILED=$(<tests/tests-summary.txt grep -o 'FAILED.*' | awk '{print $2}') &&
     [[ $NUM_FAILED = 0 ]]
 
+after_success:
+  - coveralls --include src -x .c -x .cpp
 
 # ----------------------------------------
 # Travis settings:

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ OPENMP   := no
 # to visualize the ouput, use scripts/asan_symbolize.py
 SANITIZE := no
 
+# Build with coverage support
+COVERAGE := no
+
 #############################
 # Compilers, Linkers, Testers settings
 # see make/compiler.* for supported compilers

--- a/Makefile_lib
+++ b/Makefile_lib
@@ -74,4 +74,8 @@ LDLIBS += -lstdc++ -lm
 endif
 endif
 
+ifeq ($(COVERAGE),yes)
+LDLIBS += -lgcov
+endif
+
 # end of makefile

--- a/make/compiler.g++
+++ b/make/compiler.g++
@@ -73,4 +73,8 @@ CXXFLAGS += -Wpointer-arith -Wcast-align -Wcast-qual -Winline \
 
 #           -Wfloat-equal -Wformat-nonliteral # not compatible with ugly MAD-X code...
 
+ifeq ($(COVERAGE),yes)
+CXXFLAGS += -fprofile-arcs -ftest-coverage
+endif
+
 # end of makefile

--- a/make/compiler.gcc
+++ b/make/compiler.gcc
@@ -75,4 +75,8 @@ CFLAGS += -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations \
 
 #         -Winline -Wfloat-equal -Wformat-nonliteral # not compatible with ugly MAD-X code...
 
+ifeq ($(COVERAGE),yes)
+CFLAGS += -fprofile-arcs -ftest-coverage
+endif
+
 # end of makefile


### PR DESCRIPTION
This adds coverage reports for the C part automatically generated by Travis. I think it can be very useful to get a quick impression which parts of the code the tests don't even touch.

You also have to enable MAD-X on https://coveralls.io/repos/new