### PR TITLE
Fix growth of zero-length arrays

### DIFF
--- a/src/mad_array.c
+++ b/src/mad_array.c
@@ -233,6 +233,7 @@ grow_char_array(struct char_array* p)
 {
   const char *rout_name = "grow_char_array";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->c = myrecalloc(rout_name, p->c, p->curr * sizeof *p->c, p->max * sizeof *p->c);
 }
 
@@ -241,6 +242,7 @@ grow_char_p_array(struct char_p_array* p)
 {
   const char *rout_name = "grow_char_p_array";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->p = myrecalloc(rout_name, p->p, p->curr * sizeof *p->p, p->max * sizeof *p->p);
 }
 
@@ -249,6 +251,7 @@ grow_int_array(struct int_array* p)
 {
   const char *rout_name = "grow_int_array";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->i = myrecalloc(rout_name, p->i, p->curr * sizeof *p->i, p->max * sizeof *p->i);
 }
 
@@ -257,6 +260,7 @@ grow_double_array(struct double_array* p)
 {
   const char *rout_name = "grow_double_array";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->a = myrecalloc(rout_name, p->a, p->curr * sizeof *p->a, p->max * sizeof *p->a);
 }
 
@@ -265,6 +269,7 @@ grow_char_array_list(struct char_array_list* p)
 {
   const char *rout_name = "grow_char_array_list";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->ca = myrecalloc(rout_name, p->ca, p->curr * sizeof *p->ca, p->max * sizeof *p->ca);
 }
 

--- a/src/mad_cmd.c
+++ b/src/mad_cmd.c
@@ -50,6 +50,7 @@ grow_command_list_list(struct command_list_list* p)
   const char *rout_name = "grow_command_list_list";
 //  struct command_list** c_loc = p->command_lists;
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->command_lists = myrecalloc(rout_name, p->command_lists, p->curr * sizeof *p->command_lists, p->max * sizeof *p->command_lists);
 //  p->command_lists = mycalloc(rout_name, new, sizeof *p->command_lists);
 //  for (int j = 0; j < p->curr; j++) p->command_lists[j] = c_loc[j];

--- a/src/mad_cmdin.c
+++ b/src/mad_cmdin.c
@@ -96,6 +96,7 @@ grow_in_cmd_list(struct in_cmd_list* p)
 {
   const char *rout_name = "grow_in_cmd_list";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->in_cmds = myrecalloc(rout_name, p->in_cmds, p->curr * sizeof *p->in_cmds, p->max * sizeof *p->in_cmds);
 }
 

--- a/src/mad_cmdpar.c
+++ b/src/mad_cmdpar.c
@@ -197,6 +197,7 @@ grow_command_parameter_list(struct command_parameter_list* p)
 {
   const char *rout_name = "grow_command_parameter_list";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->parameters = myrecalloc(rout_name, p->parameters, p->curr * sizeof *p->parameters, p->max * sizeof *p->parameters);
 }
 

--- a/src/mad_expr.c
+++ b/src/mad_expr.c
@@ -183,6 +183,7 @@ grow_expr_list(struct expr_list* p)
 {
   const char *rout_name = "grow_expr_list";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->list = myrecalloc(rout_name, p->list, p->curr * sizeof *p->list, p->max * sizeof *p->list);
 }
 

--- a/src/mad_name.c
+++ b/src/mad_name.c
@@ -109,6 +109,7 @@ grow_name_list(struct name_list* p)
 {
   const char *rout_name = "grow_name_list";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->names  = myrecalloc(rout_name, p->names,  p->curr * sizeof *p->names,  p->max * sizeof *p->names);
   p->index  = myrecalloc(rout_name, p->index,  p->curr * sizeof *p->index,  p->max * sizeof *p->index);
   p->inform = myrecalloc(rout_name, p->inform, p->curr * sizeof *p->inform, p->max * sizeof *p->inform);
@@ -120,6 +121,7 @@ grow_vector_list(struct vector_list* p)
   const char *rout_name = "grow_vector_list";
   struct double_array** v_loc = p->vectors;
   int new = 2*p->max;
+  if (new == 0) new++;
 
   p->max = new;
 //  p->vectors = myrealloc(rout_name, p->vectors, new * sizeof *p->vectors);

--- a/src/mad_node.c
+++ b/src/mad_node.c
@@ -133,6 +133,7 @@ grow_node_list(struct node_list* p)
 {
   const char *rout_name = "grow_node_list";
   p->max *= 2;
+  if (p->max == 0) p->max++;
   p->nodes = myrecalloc(rout_name, p->nodes, p->curr * sizeof *p->nodes, p->max * sizeof *p->nodes);
 }
 

--- a/src/mad_stream.c
+++ b/src/mad_stream.c
@@ -34,6 +34,7 @@ grow_in_buff_list(struct in_buff_list* p)
   struct in_buffer** e_loc = p->buffers;
   FILE** f_loc = p->input_files;
   int j, new = 2*p->max;
+  if (new == 0) new++;
   p->max = new;
   p->buffers = mycalloc(rout_name, new, sizeof *p->buffers);
   for (j = 0; j < p->curr; j++) p->buffers[j] = e_loc[j];

--- a/src/mad_table.c
+++ b/src/mad_table.c
@@ -164,6 +164,7 @@ grow_table_list(struct table_list* tl)
   const char *rout_name = "grow_table_list";
   struct table** t_loc = tl->tables;
   int new = 2*tl->max;
+  if (new == 0) new++;
 
   grow_name_list(tl->names);
   tl->max = new;
@@ -178,6 +179,7 @@ grow_table_list_list(struct table_list_list* tll)
   const char *rout_name = "grow_table_list_list";
   struct table_list** t_loc = tll->table_lists;
   int new = 2*tll->max;
+  if (new == 0) new++;
 
   tll->max = new;
   tll->table_lists = mycalloc(rout_name, new, sizeof *tll->table_lists);
@@ -1051,6 +1053,7 @@ grow_table(struct table* t) /* doubles number of rows */
   double* d_loc;
   struct node** p_loc = t->p_nodes;
   struct char_p_array** pa_loc = t->l_head;
+  if (new == 0) new++;
 
   t->max = new;
   t->p_nodes = mycalloc(rout_name, new, sizeof *t->p_nodes);


### PR DESCRIPTION
In many places the `grow_XXX_array` functions are used to allocate an
additional array element directly before writing into the supposedly
allocated array index without further range-checks.

Now, if an array was initialized to zero length it was never grown,
meaning that we would write after the end of the allocated buffer.

This just caught me with the `select->at` parameter which has to have
zero length by default (as defined in mad_dict.c). If you specify one or
two values for `at`, everything *seemed* to work as expected. However,
`decode_par` did not properly grow the double array and was writing the
values after the end of the buffer. When specifying a third argument,
the problem manifested by writing a NUL into the first byte of the
`flag` buffer and hence not anymore executing any selection routine.