### PR TITLE
Changed the maxiter for calculating eigenvalues. 

### DIFF
--- a/src/util.f90
+++ b/src/util.f90
@@ -370,7 +370,7 @@ end module twissbeamfi
 module max_iterate
   implicit none
   public
-  integer, parameter :: maxiter=150
+  integer, parameter :: maxiter=250
 end module max_iterate
 
 module twiss_elpfi


### PR DESCRIPTION
This should solve the problem with high-lumi masks.