### PR TITLE
Fix aperture plot

### DIFF
--- a/src/mad_inter.c
+++ b/src/mad_inter.c
@@ -49,6 +49,7 @@ interpolate_node(int *nint)
 
   backup.first_node = clone;
   current_node      = clone;
+  clone->master     = backup.current_node;
 
   if (bend_flag) {
     angle = command_par_value("angle", el->def);
@@ -82,6 +83,7 @@ interpolate_node(int *nint)
     clone = clone_node(current_node, 0);
     current_node->next = clone;
     clone->previous = current_node;
+    clone->master = backup.current_node;
     current_node = clone;
     current_node->other_bv = bvk;
   }

--- a/src/mad_node.c
+++ b/src/mad_node.c
@@ -215,7 +215,6 @@ expand_node(struct node* node, struct sequence* top_sequ, struct sequence* sequ,
 
 
     if (p->p_sequ == NULL){ // simple element, not a subsequence
-      p->share = top_sequ->share;
       add_to_node_list(p, 0, top_sequ->ex_nodes);
     }
 

--- a/src/mad_node.h
+++ b/src/mad_node.h
@@ -18,7 +18,6 @@ struct node                /* the sequence is a linked list of nodes */
   struct node* previous;
   struct node* next;
   struct node* master;     /* ancestor for interpolated nodes */
-  int share;               /* 0 normal, 1 if shared */
   int occ_cnt;             /* element occurrence count at node */
   int obs_point;           /* observation point number (tracking) */
   int sel_err;             /* error select flag */

--- a/src/mad_node.h
+++ b/src/mad_node.h
@@ -17,6 +17,7 @@ struct node                /* the sequence is a linked list of nodes */
   char* base_name;         /* basic type */
   struct node* previous;
   struct node* next;
+  struct node* master;     /* ancestor for interpolated nodes */
   int share;               /* 0 normal, 1 if shared */
   int occ_cnt;             /* element occurrence count at node */
   int obs_point;           /* observation point number (tracking) */

--- a/src/mad_table.c
+++ b/src/mad_table.c
@@ -857,7 +857,8 @@ augment_count(const char* table) /* increase table occ. by 1, fill missing */
 
   if (t->num_cols > t->org_cols)  add_vars_to_table(t,1);
 
-  if (t->p_nodes != NULL) t->p_nodes[t->curr] = current_node;
+  if (t->p_nodes != NULL)
+    t->p_nodes[t->curr] = current_node->master ? current_node->master : current_node;
 
   if (t->node_nm != NULL)
   {


### PR DESCRIPTION
Hi,

this contains the fix for the bug introduced by #429 that Laurent described by mail to me: plotting the aperture table results results in a plot that stops at the first interpolated element. The reason is that the plotting routine works with `advance_to_pos` which uses `table::p_nodes` which were pointing to the temporary (invalid) nodes. With the fix, the table entry will always point to the template node that was used to interpolate the current node.

However, note that with this patch, while generating the expected plot, the example produces new warnings:

```
++++++ warning: double_from_table_row: column not found: aperture->k1l
++++++ warning: double_from_table_row: column not found: aperture->k1sl
++++++ warning: double_from_table_row: column not found: aperture->k2l
++++++ warning: double_from_table_row: column not found: aperture->k2sl
++++++ warning: double_from_table_row: column not found: aperture->k3l
++++++ warning: double_from_table_row: column not found: aperture->k3sl
```

for each interpolated node. These come from `plot.f90` line 462-470 (in `pefill`).

The reason is that with the patch, `currtyp = node_value('mad8_type ')` is (correctly?!) deduced as the value `5` (which means `code_quadrupole`, according to `util.f90`), and apparently the aperture table does not contain the required columns. Before #429, the `currtyp` was `1` (drift) for all interpolated nodes.

So, there are two plausible fixes:
- in `pefill` check if the table contains the required columns and skip the if-case otherwise
- add these columns to the aperture output table 

IMO, the best solution is to do both. What do you think?

Best, Thomas


Example to reproduce:

```fortran
!----generic test sequences----------------------------------------
KQ1 = 0.01;
KQ2 = -0.01;

testseq: SEQUENCE, l = 50.0;
  MQ1.s: QUADRUPOLE, K1=KQ1, l= 2, at=15, APERTYPE=CIRCLE, APERTURE={0.02};
  MQ2.s: QUADRUPOLE, K1=KQ2, l= 2, at=45, APERTYPE=CIRCLE, APERTURE={0.02};
ENDSEQUENCE;

BEAM, PARTICLE=PROTON, ENERGY=7000.0, EXN=2.2e-6, EYN=2.2e-6;

!---TWISS and APERTURE
USE, SEQUENCE=testseq;
TWISS, BETX=100, BETY=100;
APERTURE, file="aperture.out";

!---THIS plot works for MADX 5.03.06 but not for 5.03.07
PLOT, TABLE=APERTURE, HAXIS=S, VAXIS1=N1, VAXIS2=BETX, VMAX=110, NOLINE, NOTITLE, NOVERSION;
```
