### PR TITLE
Bugfix select

### DIFF
--- a/src/mad_select.c
+++ b/src/mad_select.c
@@ -107,13 +107,12 @@ pass_select(char* name, struct command* sc)
   /* Don't use for selecting elements. It may not find all elements. */
 {
   struct element* el = find_element(strip(name), element_list);
-  return pass_select_el(el, sc);
+  return el ? pass_select_el(el, sc) : pass_select_str(name, sc);
 }
-
 
 int
 pass_select_el(struct element* el, struct command* sc)
-  /* checks name against class (if element) and pattern that may
+  /* checks element against class and pattern that may
      (but need not) be contained in command sc;
      0: does not pass, 1: passes */
   /* Should use this function in favor of `pass_select` where possible. It
@@ -134,13 +133,26 @@ pass_select_el(struct element* el, struct command* sc)
       if (in == 0) return 0;
     }
   }
+  return pass_select_str(el->name, sc);
+}
+
+int pass_select_str(const char* name, struct command* sc)
+{
+  /* checks name against pattern that may
+     (but need not) be contained in command sc;
+     0: does not pass, 1: passes */
+  struct name_list* nl = sc->par_names;
+  struct command_parameter_list* pl = sc->par;
+  int pos, in = 0, any = 0;
+  char *pattern;
+
   any = in = 0;
   pos = name_list_pos("pattern", nl);
   if (pos > -1 && nl->inform[pos])  /* parameter has been read */
   {
     any = 1;
     pattern = stolower(pl->parameters[pos]->string);
-    if(myregex(pattern, strip(el->name)) == 0)  in = 1;
+    if(myregex(pattern, strip(name)) == 0)  in = 1;
   }
   if (any == 0) return 1;
   else return in;
@@ -149,12 +161,14 @@ pass_select_el(struct element* el, struct command* sc)
 int
 pass_select_list(char* name, struct command_list* cl)
   /* returns 0 (does not pass) or 1 (passes) for a list of selects */
-  /* Don't use for selecting elements. It may not find all elements. */
+  /* Don't use for selecting elements! It may not find all elements. */
 {
-  struct element* el = find_element(strip(name), element_list);
-  return pass_select_list_el(el, cl);
+  for (int i = 0; i < cl->curr; i++) {
+    if (pass_select(name, cl->commands[i]))
+        return 1;
+  }
+  return cl->curr == 0;
 }
-
 
 int
 pass_select_list_el(struct element* el, struct command_list* cl)

--- a/src/mad_select.c
+++ b/src/mad_select.c
@@ -159,12 +159,12 @@ int pass_select_str(const char* name, struct command* sc)
 }
 
 int
-pass_select_list(char* name, struct command_list* cl)
+pass_select_list_str(const char* name, struct command_list* cl)
   /* returns 0 (does not pass) or 1 (passes) for a list of selects */
   /* Don't use for selecting elements! It may not find all elements. */
 {
   for (int i = 0; i < cl->curr; i++) {
-    if (pass_select(name, cl->commands[i]))
+    if (pass_select_str(name, cl->commands[i]))
         return 1;
   }
   return cl->curr == 0;

--- a/src/mad_select.h
+++ b/src/mad_select.h
@@ -18,7 +18,7 @@ struct element;
 
 void  store_select(struct in_cmd*);
 void  store_deselect(struct in_cmd*);
-int   pass_select(char* name, struct command*);                         // deprecated
+int   pass_select(const char* name, struct command*);                   // deprecated
 int   pass_select_str(const char* name, struct command*);               // not for elements!
 int   pass_select_el(struct element* el, struct command*);
 int   pass_select_list_str(const char* name, struct command_list*);     // not for elements!

--- a/src/mad_select.h
+++ b/src/mad_select.h
@@ -18,10 +18,10 @@ struct element;
 
 void  store_select(struct in_cmd*);
 void  store_deselect(struct in_cmd*);
-int   pass_select(char* name, struct command*);             // deprecated
-int   pass_select_list(char* name, struct command_list*);   // deprecated
-int   pass_select_str(const char* name, struct command*);   // not for elements!
+int   pass_select(char* name, struct command*);                         // deprecated
+int   pass_select_str(const char* name, struct command*);               // not for elements!
 int   pass_select_el(struct element* el, struct command*);
+int   pass_select_list_str(const char* name, struct command_list*);     // not for elements!
 int   pass_select_list_el(struct element* el, struct command_list*);
 void  get_select_t_ranges(struct command_list* select, struct command_list* deselect, struct table*);
 int   get_select_ranges(struct sequence* sequ, struct command_list* select, struct node_list* s_ranges);

--- a/src/mad_select.h
+++ b/src/mad_select.h
@@ -20,6 +20,7 @@ void  store_select(struct in_cmd*);
 void  store_deselect(struct in_cmd*);
 int   pass_select(char* name, struct command*);             // deprecated
 int   pass_select_list(char* name, struct command_list*);   // deprecated
+int   pass_select_str(const char* name, struct command*);   // not for elements!
 int   pass_select_el(struct element* el, struct command*);
 int   pass_select_list_el(struct element* el, struct command_list*);
 void  get_select_t_ranges(struct command_list* select, struct command_list* deselect, struct table*);

--- a/src/mad_seq.c
+++ b/src/mad_seq.c
@@ -754,7 +754,7 @@ export_sequ_8(struct sequence* sequ, struct command_list* cl, FILE* file)
 
   seqref = sequ->ref_flag;  /* uncomment line to get entry or exit */
 
-  if (pass_select_list(sequ->name, cl) == 0)  return;
+  if (pass_select_list_str(sequ->name, cl) == 0)  return;
 
   *c_dum->c = '\0';
   strcat(c_dum->c, sequ->export_name);
@@ -820,7 +820,7 @@ write_sequs(struct sequence_list* sql,struct command_list* cl, FILE* file, int n
     for (i = 0; i < sql->curr; i++)
       if(sql->sequs[i]->nested == j)
       {
-        if (pass_select_list(sql->sequs[i]->name, cl))
+        if (pass_select_list_str(sql->sequs[i]->name, cl))
           export_sequence(sql->sequs[i], file, noexpr);
       }
   }

--- a/src/mad_var.c
+++ b/src/mad_var.c
@@ -253,7 +253,7 @@ void
 write_vars(struct var_list* varl, struct command_list* cl, FILE* file, int noexpr)
 {
   for (int i = 0; i < varl->curr; i++) {
-    if (predef_var(varl->vars[i]) == 0 && pass_select_list(varl->vars[i]->name, cl))
+    if (predef_var(varl->vars[i]) == 0 && pass_select_list_str(varl->vars[i]->name, cl))
       export_variable(varl->vars[i], file, noexpr);
   }
 }
@@ -265,7 +265,7 @@ write_vars_8(struct var_list* varl, struct command_list* cl, FILE* file)
   for (i = 0; i < varl->curr; i++)
   {
     if (predef_var(varl->vars[i]) == 0
-        && pass_select_list(varl->vars[i]->name, cl))
+        && pass_select_list_str(varl->vars[i]->name, cl))
       export_var_8(varl->vars[i], file);
   }
 }


### PR DESCRIPTION
Resolves #492. 

The bug is due to an error on my part, introduced by 674555f5966d47e53cd3abccf08bf6b08f94b2c0. Back then, I didn't properly check that `pass_select` is used in two separate contexts:

- select elements by class + pattern
- select (var/seq) names by pattern only

Not properly handling the second case is the cause for #492.

The first commit restores the original behaviour (pre 674555f5966d47e53cd3abccf08bf6b08f94b2c0). The others fix flaws with the original handling of the second case:

`pass_select` should not consider SELECT statements in which CLASS appears as wildcards for variable/sequence names, because these were obviously meant to select elements.

Best, Thomas