### PR TITLE
MadX syntax highlighting version 0.1.2 for atom (experimental)

### DIFF
--- a/syntax/README.txt
+++ b/syntax/README.txt
@@ -16,3 +16,4 @@ Emacs : Emacs is a text editor based on lisp. Check the file madx.el to load the
      but any buffer can be highlighted by doing in emacs "META-x", typing "madx-mode", and RETURN.
      NOTE: META is the emacs meta-character, it seems that in linux META is the same as ALT.
 
+Atom: Syntax highlighting for MadX can either be installed by copying the folder language-madx to $HOME/.atom/packages/ (on Linux), or by searching for language-madx in the Atom package manager. The highlighting is automatically enabled for *.madx and *.seq files.

--- a/syntax/atom/language-madx/CHANGELOG.md
+++ b/syntax/atom/language-madx/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.1.1 [2017-11-10] - Initial Release
+## 0.1.2 [2017-11-12] - Bug Fix and Minor Changes
+* Fixed mistypen class
+* Moved some more patterns into pattern repository
+* Added `*.mask` files to fileTypes
+
+## 0.1.1 [2017-11-10] - Bug Fix
 * Fixed bug in number formatting
 
 ## 0.1.0 [2017-11-10] - Initial Release

--- a/syntax/atom/language-madx/CHANGELOG.md
+++ b/syntax/atom/language-madx/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.1.1 [2017-11-10] - Initial Release
+* Fixed bug in number formatting
+
+## 0.1.0 [2017-11-10] - Initial Release
+* First version of the package

--- a/syntax/atom/language-madx/LICENSE.md
+++ b/syntax/atom/language-madx/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Veronica Berglyd Olsen
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/syntax/atom/language-madx/README.md
+++ b/syntax/atom/language-madx/README.md
@@ -1,0 +1,9 @@
+# Atom Package: language-madx
+
+Written by: Veronica Berglyd Olsen, CERN BE/ABP/HSS
+
+Syntax highlighting for [MadX](http://mad.web.cern.ch/mad/) input and scripting files for the Atom editor.
+
+MAD (Methodical Accelerator Design) is developed and maintained at [CERN](http://cern.ch).
+It is a simulation and design code for particle accelerators. This package provides syntax highlighting
+for `*.madx` and `*.seq` files used with this code.

--- a/syntax/atom/language-madx/grammars/madx.cson
+++ b/syntax/atom/language-madx/grammars/madx.cson
@@ -4,22 +4,13 @@
 'fileTypes': [
   'madx'
   'seq'
+  'mask'
 ]
 'patterns': [
   { 'include': '#comments' }
   { 'include': '#numbers' }
-  {
-    'match': '==|<>|<|>|<=|=>'
-    'name': 'keyword.operator.comparison.c'
-  }
-  {
-    'match': '(?i)\\b(?<!\\.)(const)\\b'
-    'name': 'storage.modifier.madx'
-  }
-  {
-    'match': '(?i)\\b(?<!\\.)(real|int)\\b'
-    'name': 'storage.type.madx'
-  }
+  { 'include': '#types' }
+  { 'include': '#operators' }
   {
     'match': '(?i)\\b(?<!\\.)(if|elseif|else|while|macro)\\b'
     'name': 'keyword.control.madx'
@@ -231,5 +222,21 @@
         'name': 'punctuation.separator.decimal.period.madx'
       '2':
         'name': 'punctuation.separator.decimal.period.madx'
-    
-    
+  'types':
+    'patterns': [
+      {
+        'match': '(?i)\\b(?<!\\.)(const)\\b'
+        'name': 'storage.modifier.madx'
+      }
+      {
+        'match': '(?i)\\b(?<!\\.)(real|int)\\b'
+        'name': 'storage.type.madx'
+      }
+    ]
+  'operators':
+    'patterns': [
+      {
+        'match': '==|<>|<|>|<=|=>'
+        'name': 'keyword.operator.comparison.madx'
+      }
+    ]

--- a/syntax/atom/language-madx/grammars/madx.cson
+++ b/syntax/atom/language-madx/grammars/madx.cson
@@ -1,0 +1,235 @@
+'comment': 'MadX'
+'name': 'MadX'
+'scopeName': 'source.madx'
+'fileTypes': [
+  'madx'
+  'seq'
+]
+'patterns': [
+  { 'include': '#comments' }
+  { 'include': '#numbers' }
+  {
+    'match': '==|<>|<|>|<=|=>'
+    'name': 'keyword.operator.comparison.c'
+  }
+  {
+    'match': '(?i)\\b(?<!\\.)(const)\\b'
+    'name': 'storage.modifier.madx'
+  }
+  {
+    'match': '(?i)\\b(?<!\\.)(real|int)\\b'
+    'name': 'storage.type.madx'
+  }
+  {
+    'match': '(?i)\\b(?<!\\.)(if|elseif|else|while|macro)\\b'
+    'name': 'keyword.control.madx'
+  }
+  {
+    'begin': '''(?xi)\\b(?<!\\.)
+      (table|tabindex|tabstring|gettab|getidx)
+      (\\s*\\()
+    '''
+    'beginCaptures' :
+      '1': 'name': 'support.function.madx'
+      '2': 'name': 'punctuation.madx'
+    'patterns': [
+      { 'include': '#internals' }
+      { 'include': '#numbers' }
+      { 'include': '#strings' }
+    ]
+    'end': '\\)'
+    'endCaptures' :
+      '0': 'name': 'punctuation.madx'
+  }
+  {
+    'begin': '''(?xi)\\b(?<!\\.)
+      (
+        assign|
+        beam|
+        call|coguess|constraint|copyfile|clear|create|cycle|
+        delete|dumpsequ|
+        exec|extract|
+        fill|fill_knob|
+        global|gweight|
+        help|
+        install|
+        migrad|move|
+        option|
+        plot|print|printf|
+        readmytable|readtable|remove|removefile|renamefile|replace|resbeam|resplot|
+        save|select|set|setvars|setvars_const|setvars_knob|setvars_lin|seqedit|
+        show|shrink|sixtrack|sxfread|sxfwrite|survey|system|
+        title|twiss|
+        use|write|
+        value|vary|
+        weight
+      )
+      (\\s*\\,)
+    '''
+    'beginCaptures' :
+      '1': 'name': 'keyword.control.madx'
+      '2': 'name': 'punctuation.madx'
+    'patterns': [
+      { 'include': '#attributes' }
+      { 'include': '#flags' }
+      { 'include': '#internals' }
+      { 'include': '#particles' }
+      { 'include': '#numbers' }
+      { 'include': '#strings' }
+    ]
+    'end': ';'
+    'endCaptures' :
+      '0': 'name': 'punctuation.madx'
+  }
+  {
+    'match': '(?i)\\b(?<!\\.)(exit|quit|stop|flatten|reflect|endedit|clear|twiss)\\b'
+    'name': 'keyword.control.madx'
+  }
+  { 'include': '#internals' }
+  { 'include': '#math' }
+  { 'include': '#strings' }
+  {
+    'match': ';'
+    'name': 'punctuation.terminator.statement.madx'
+  }
+  {
+    'match': ','
+    'name': 'punctuation.separator.delimiter.madx'
+  }
+]
+'repository':
+  'attributes':
+    'patterns': [
+      {
+        'match': '(?xi)\\b([a-zA-Z_]+)\\s*(=)'
+        'captures':
+          '1': 'name': 'variable.other.madx'
+          '2': 'name': 'punctuation.madx'
+      }
+      { 'include' : '#attributes-singular' }
+    ]
+  'attributes-singular':
+    'match': '''(?xi)\\b(?<!\\.)
+      (
+        bborbit|bunched|
+        cavall|clear|
+        debug|
+        echo|echomacro|
+        full|
+        info|
+        no_fatal_stop|
+        radiate|rbarc|reset|
+        sympl|
+        tell|thick|thin_foc|threader|trace|truncate|twiss_print|
+        verbose|verify|
+        warn
+      )\\b
+    '''
+    'name': 'variable.other.madx'
+  'internals':
+    'patterns': [
+      {
+        'match': '''(?xi)\\b(?<!\\.)
+          (pi|twopi|degrad|raddeg|e|emass|pmass|nmass|mumass|clight|qelect|hbar|erad|prad)
+          (?!\\.)\\b
+        '''
+        'name': 'constant.language.madx'
+      }
+      {
+        'match': '''(?xi)\\b(?<!\\.)
+          (twiss|beam)
+          \\b
+        '''
+        'name': 'variable.language.madx'
+      }
+    ]
+  'flags':
+    'match': '''(?xi)\\b(?<!\\.)
+      (error|makethin|save|sectormap|seqedit)
+      \\b
+    '''
+    'name': 'constant.flag.madx'
+  'particles':
+    'match': '''(?xi)\\b(?<!\\.)
+      (positron|electron|proton|antiproton|posmuon|negmuon|ion)
+      \\b
+    '''
+    'name': 'constant.flag.madx'
+  'math':
+    'match': '''(?xi)\\b(?<!\\.)
+      (sqrt|log|log10|exp|sin|cos|tan|asin|acos|atan|sinh|cosh|tanh|sinc|abs|erf|erfc|
+      floor|ceil|round|frac|ranf|gauss|tgauss)
+      \\b
+    '''
+    'name': 'support.function.madx'
+  'comments':
+    'patterns': [
+      {
+        'begin': '!'
+        'end': '\\n'
+        'name': 'comment.line.madx'
+      }
+      {
+        'begin': '//'
+        'end': '\\n'
+        'name': 'comment.line.madx'
+      }
+      {
+        'begin': '/\\*'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.begin.madx'
+        'end': '\\*/'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.end.madx'
+        'name': 'comment.block.madx'
+      }
+    ]
+  'strings':
+    'patterns': [
+      {
+        'begin': '"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.madx'
+        'end': '"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.madx'
+        'name': 'string.quoted.double.madx'
+        'patterns': [
+          {
+            'match': '\\\\.'
+            'name': 'constant.character.escape.madx'
+          }
+        ]
+      }
+      {
+        'begin': '\''
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.madx'
+        'end': '\''
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.madx'
+        'name': 'string.quoted.single.madx'
+        'patterns': [
+          {
+            'match': '\\\\.'
+            'name': 'constant.character.escape.madx'
+          }
+        ]
+      }
+    ]
+  'numbers':
+    'match': '\\b(?<!\\.)([0-9]+\\.?[0-9]*[eE]?[\\+\\-]?)\\b'
+    'name': 'constant.numeric.madx'
+    'captures':
+      '1':
+        'name': 'punctuation.separator.decimal.period.madx'
+      '2':
+        'name': 'punctuation.separator.decimal.period.madx'
+    
+    

--- a/syntax/atom/language-madx/package.json
+++ b/syntax/atom/language-madx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-madx",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MadX language support in Atom",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"

--- a/syntax/atom/language-madx/package.json
+++ b/syntax/atom/language-madx/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "language-madx",
+  "version": "0.1.1",
+  "description": "MadX language support in Atom",
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  },
+  "homepage": "https://github.com/vkbo/languageMadX",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vkbo/languageMadX"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/vkbo/languageMadX/issues"
+  }
+}


### PR DESCRIPTION
This is just a first attempt at adding syntax highlighting for MadX in atom. It seems to work fine on all files I've tested it on, but there may be a few issues with erroneously highlighting parts variables with dots as numbers still.