### PR TITLE
Fixed column separation in sixtrack export to fc.2

### DIFF
--- a/src/mad_6track.c
+++ b/src/mad_6track.c
@@ -3278,7 +3278,7 @@ write_struct(void)
     {
       fprintf(f2,"\n"); lc = 1;
     }
-    fprintf(f2, "%-18s", name);
+    fprintf(f2, "%-17s ", name);
     p = p->next;
   }
   if (lc > 0)


### PR DESCRIPTION
When element names are 18 characters or longer, there are no more spaces separating one element from the next. This happens frequently when the aperture flag is added to sixtrack output. This fix adds a space at the end of the formatting to ensure it is always possible to split the elements on a single line.

This is a temporary fix. SixTrack does not support names longer than 16 characters. But this allows the files to be post processed before using them with SixTrack.