### PR TITLE
Fix broken MVAR in "slow" matching

### DIFF
--- a/src/mad_const.c
+++ b/src/mad_const.c
@@ -171,7 +171,7 @@ fill_constraint_list(int type /* 1 node, 2 global */,
   struct command_parameter_list* pl = cd->par;
   struct name_list* nl = cd->par_names;
   struct constraint* l_cons;
-  int j, find_npos = type == 1 && !get_option("slow");
+  int j, find_npos = type == 1 && !get_option("slow_match");
   struct command* weights = type == 1 ? current_weight : current_gweight;
   double weight = command_par_value("weight", cd);
   int use_weight = par_present("weight", cd);


### PR DESCRIPTION
Regression bug due to 345bd8632ecb1a7b6cd307b72af8fcb8d954007d.

Fixes #543.