### PR TITLE
Fix parsing negated logical after string parameter

### DIFF
--- a/src/mad_cmdpar.c
+++ b/src/mad_cmdpar.c
@@ -857,7 +857,7 @@ decode_par(struct in_cmd* cmd, int start, int number, int pos, int log)
         for (j = i; j < number; j++)
           if (name_list_pos(alias(toks[j]), cmd->cmd_def->par_names) >= 0) break;
 //        dirty quick fix for ticket #165
-//        if (*toks[j-1] == ',') j--;
+          if (*toks[j-1] == '-') j--;
           while (*toks[j-1] == ',') j--;
         tot_end = j - 1;
         clp->string = permbuff(noquote(join(&toks[i], j - i)));


### PR DESCRIPTION
Fixes parsing expressions such as:

    beam, sequence=s1, -radiate;

which was so far parsed as:

    beam, sequence="s1,-", radiate;

Example:

    s1: sequence, l=1;
    endsequence;
    beam, sequence=s1, -radiate;
    use, sequence=s1;

    +=+=+= fatal: USE - sequence without beam: sequ