### PR TITLE
GC bug: fix list of page attributes to check for registering pages as roots

### DIFF
--- a/libs/gc/gc-7.2f/dyn_load.c
+++ b/libs/gc/gc-7.2f/dyn_load.c
@@ -944,6 +944,9 @@ GC_INNER void GC_register_dynamic_libraries(void)
             protect = buf.Protect;
             if (buf.State == MEM_COMMIT
                 && (protect == PAGE_EXECUTE_READWRITE
+                    || protect == PAGE_EXECUTE_WRITECOPY
+                    || protect == PAGE_READWRITE
+                    || protect == PAGE_WRITECOPY)
                     || protect == PAGE_READWRITE)
                 && (buf.Type == MEM_IMAGE
 #                   ifdef GC_REGISTER_MEM_PRIVATE

--- a/libs/gc/gc-7.6.4/dyn_load.c
+++ b/libs/gc/gc-7.6.4/dyn_load.c
@@ -1019,7 +1019,9 @@ GC_INNER void GC_register_dynamic_libraries(void)
             protect = buf.Protect;
             if (buf.State == MEM_COMMIT
                 && (protect == PAGE_EXECUTE_READWRITE
-                    || protect == PAGE_READWRITE)
+                    || protect == PAGE_EXECUTE_WRITECOPY
+                    || protect == PAGE_READWRITE
+                    || protect == PAGE_WRITECOPY)
                 && (buf.Type == MEM_IMAGE
 #                   ifdef GC_REGISTER_MEM_PRIVATE
                       || (protect == PAGE_READWRITE && buf.Type == MEM_PRIVATE)


### PR DESCRIPTION
Without this fix, the GC was not registering some pages that contained global variables, include the main and mostly used buffer c_dum. Hence, MADX was crashing during initialisation where many global buffers are preallocated.