### PR TITLE
Prevents aperture moduel to run with wrong setting of twiss

### DIFF
--- a/src/mad_seq.h
+++ b/src/mad_seq.h
@@ -50,6 +50,7 @@ struct sequence
   struct node_list* ex_nodes;   /* alphabetic list of nodes (no drifts) */
   struct table* tw_table;       /* pointer to latest twiss table created */
   int           tw_valid;       /* true if current tw_table is valid */
+  int           tw_centre;      /* true if twiss center option is triggered */        
   struct constraint_list* cl;   /* pointer to constraint list during match */
   struct vector_list* orbits;   /* pointer to list of stored orbits */
 };

--- a/src/mad_twiss.c
+++ b/src/mad_twiss.c
@@ -762,11 +762,19 @@ pro_twiss(void)
     }
   }
 
-  if(par_present("centre", current_twiss)) set_option("centre", &k);
+  if(par_present("centre", current_twiss)) {
+    set_option("centre", &k);
+    // Special check that it really is set to TRUE (not only included in the argument)
+    if(command_par_value("centre", current_twiss)>0){
+      current_sequ->tw_centre=1;
+    }
+  }
   else {
     k = 0;
+    current_sequ->tw_centre=0;
     set_option("centre", &k);
     k = 1;
+
   }
 
   name = command_par_string_user("keeporbit", current_twiss);
@@ -1023,6 +1031,7 @@ embedded_twiss(void)
   {
     /* beta0 specified */
     embedded_twiss_beta[0] = buffer(cp->m_string->p[0]);
+
 
     /* START defining a TWISS input command for the sequence */
     tnl = local_twiss[0]->cmd_def->par_names;


### PR DESCRIPTION
This PR fixes the issue that aperture gave wrong results with twiss, center. It is now a forbidden setting and mad-x do not output any aperture if this is chosen. The special case where there are only thin aperture object is accepted since the problem is creating the extra nodes needed for the extra slices. 