### PR TITLE
Rename mad_error to avoid name collision with error(3)

### DIFF
--- a/src/mad_cmdpar.c
+++ b/src/mad_cmdpar.c
@@ -300,7 +300,7 @@ export_comm_par(struct command_parameter* par, char* string, int noexpr)
       strcat(string, "}");
       break;
     }
-    default: error("export command param", "invalid type %d", par->type);
+    default: mad_error("export command param", "invalid type %d", par->type);
   }
 }
 

--- a/src/mad_core.c
+++ b/src/mad_core.c
@@ -22,7 +22,7 @@ mad_init_c(void)
   // quick and dirty fix to accept jobs from filename
   in->input_files[0] = mad_argc > 1 ? fopen(mad_argv[1], "r") : stdin;
   if (!in->input_files[0]) {
-    error("invalid input filename ", " %s", mad_argv[1]);
+    mad_error("invalid input filename ", " %s", mad_argv[1]);
     in->input_files[0] = stdin;
   }
   interactive = intrac();

--- a/src/mad_elem.c
+++ b/src/mad_elem.c
@@ -478,26 +478,26 @@ element_value(const struct node* node, const char* par)
   double e_val;
 
   if (node == 0) {
-     error("element_value","node parameter is NULL.");
+     mad_error("element_value","node parameter is NULL.");
      return 0.0;
    }
 
   const struct element* el = node->p_elem;
 
    if (el == 0) {
-     error("element_value","node has NULL element pointer.");
+     mad_error("element_value","node has NULL element pointer.");
      return 0.0;
    }
 
    if (strcmp(el->name,"in_cmd") == 0) {
-     error("element_value","node '%.47s' refers to invalid element (improper (re)definition?).", node->name);
+     mad_error("element_value","node '%.47s' refers to invalid element (improper (re)definition?).", node->name);
      return 0.0;
    }
 
    const struct command* def = el->def;
 
    if (def == 0) {
-     error("element_value","element has NULL defintion pointer.");
+     mad_error("element_value","element has NULL defintion pointer.");
      return 0.0;
    }
 

--- a/src/mad_elemerr.c
+++ b/src/mad_elemerr.c
@@ -669,7 +669,7 @@ error_efcomp(struct in_cmd* cmd)
 		      /* NORMAL COMPONENTS, RELATIVE ERRORS, MAY BE CORRECTED FOR MEMORY EFFECTS */
               if(i==2) {
 		            if(rr < 1.0E-6) {
-		              error("trying to assign relative field errors with no or zero reference radius specified","");
+		              mad_error("trying to assign relative field errors with no or zero reference radius specified","");
 		            }
 		            double norfac = pow(rr,(order-j)) * (fact(j)/fact(order));
 
@@ -694,7 +694,7 @@ error_efcomp(struct in_cmd* cmd)
   		    /* SKEW COMPONENTS, RELATIVE ERRORS, MAY BE CORRECTED FOR MEMORY EFFECTS */
               if(i==3) {
                 if(rr < 1.0E-6) {
-                  error("trying to assign relative field errors with no or zero reference radius specified","");
+                  mad_error("trying to assign relative field errors with no or zero reference radius specified","");
       		      }
 		            double norfac = pow(rr,(order-j)) * (fact(j)/fact(order));
 

--- a/src/mad_err.c
+++ b/src/mad_err.c
@@ -41,8 +41,8 @@ seterrorflag(int errcode, const char* from, const char* descr)
 /*Sets error flag - Used to comunicate occurance of an error.
   Mainly between c and fortran parts*/
   errorflag = errcode;
-  error("seterrorflag","Errorcode: %d   Reported from %s:",errorflag,from);
-  error("seterrorflag","Description: %s",descr);
+  mad_error("seterrorflag","Errorcode: %d   Reported from %s:",errorflag,from);
+  mad_error("seterrorflag","Description: %s",descr);
 }
 
 int
@@ -91,7 +91,7 @@ warningnew(const char* t1, const char* fmt, ...)
 }
 
 void
-error(const char* t1, const char* fmt, ...)
+mad_error(const char* t1, const char* fmt, ...)
 {
 /*prints warning on the standard error and accepts parameters printout with std C formatting*/
 /*Piotr Skowronski CERN*/

--- a/src/mad_err.h
+++ b/src/mad_err.h
@@ -16,7 +16,7 @@ void  fatal_error (const char* t1, const char* t2);
 
 // used in C only
 void  warningnew  (const char* t1, const char* fmt, ...);
-void  error       (const char* t1, const char* fmt, ...);
+void  mad_error   (const char* t1, const char* fmt, ...);
 
 // used only in madx_finish
 void  mad_err_getwarn(int* cwarn, int* fwarn);

--- a/src/mad_match2.c
+++ b/src/mad_match2.c
@@ -37,7 +37,7 @@ match2_augmentnconstraints(void)
   struct expression* * new_match2_cons_lhs = 0x0;
 
   if(MAX_MATCH_MACRO == 0) {
-    error("match2_augmentnconstraints","match with use_maco was not initialized");
+    mad_error("match2_augmentnconstraints","match with use_maco was not initialized");
     return 1;
   }
 
@@ -205,7 +205,7 @@ match2_disasambleconstraint(struct in_cmd* cmd)
     k = get_ex_range(name, sequ, nodes);
     if (k == 0)
     {
-      error("match2_disasambleconstraint","Bad range! Ignoring\n");
+      mad_error("match2_disasambleconstraint","Bad range! Ignoring\n");
       return;
     }
   }
@@ -290,7 +290,7 @@ match2_augmentnmacros(void)
   struct expression* **new_match2_cons_lhs;
 
   if(MAX_MATCH_MACRO == 0) {
-    error("match2_augmentnconstraints","match with use_maco was not initialized");
+    mad_error("match2_augmentnconstraints","match with use_maco was not initialized");
     return 1;
   }
 

--- a/src/mad_ptc.c
+++ b/src/mad_ptc.c
@@ -146,7 +146,7 @@ pro_ptc_select_checkpushtable(struct in_cmd* cmd, struct int_array** tabnameIA, 
   pos = name_list_pos(columnname,aTable->columns);
   if (pos < 0)
   {
-    error("mad_ptc.c: pro_ptc_select","Can not find column named <<%s>> in table <<%s>>.",
+    mad_error("mad_ptc.c: pro_ptc_select","Can not find column named <<%s>> in table <<%s>>.",
           columnname,aTable->name);
     return 7;
   }
@@ -772,7 +772,7 @@ pro_ptc_enforce6d(struct in_cmd* cmd)
 
   if (cmd->clone == 0x0)
   {
-    error("pro_ptc_enforce6d","Command Definintion is null!!!");
+    mad_error("pro_ptc_enforce6d","Command Definintion is null!!!");
     return;
   }
 

--- a/src/mad_ptcknobs.c
+++ b/src/mad_ptcknobs.c
@@ -163,7 +163,7 @@ findsetknob(char* ename, int exactnamematch, char* initialpar)
         }
         else
         {
-          error("findsetknob","A knob for such named element(s) found, but name matching flag does not agree.");
+          mad_error("findsetknob","A knob for such named element(s) found, but name matching flag does not agree.");
           return -i;
         }
       }
@@ -177,7 +177,7 @@ findsetknob(char* ename, int exactnamematch, char* initialpar)
       bconta = strstr(madx_mpk_knobs[i].elname, ename);
       if ( (acontb && (exactnamematch == 0)) || (bconta && (madx_mpk_knobs[i].exactnamematch  == 0)) )
       {
-        error("findsetknob",
+        mad_error("findsetknob",
               "This variable (name %s, exactmatch %d) can cause ambiguity with another already defined variable (name %s, exactmatch %d)",
               ename, exactnamematch, madx_mpk_knobs[i].elname, madx_mpk_knobs[i].exactnamematch);
         return -i;
@@ -194,7 +194,7 @@ findsetknob(char* ename, int exactnamematch, char* initialpar)
         if (( strcmp(initialpar,madx_mpk_knobs[i].initial) == 0 ))
         {
 
-          error("findsetknob","Such initial parameter is already defined");
+          mad_error("findsetknob","Such initial parameter is already defined");
           return -i;
         }
       }
@@ -456,7 +456,7 @@ madx_mpk_scalelimits(int nv)
 
   if ( (nv < 0) || (nv >= MAX_KNOBS) )
   {
-    error("madx_mpk_scalelimits","Passed variable out of range");
+    mad_error("madx_mpk_scalelimits","Passed variable out of range");
     return 1;
   }
 
@@ -503,7 +503,7 @@ madx_mpk_scalelimits(int nv)
  *    }
  *   if (el == 0x0)
  *    {
- *      error("madx_mpk_scalelimits","Can not find element named %s in the current sequence",madx_mpk_knobs[v->knobidx].elname);
+ *      mad_error("madx_mpk_scalelimits","Can not find element named %s in the current sequence",madx_mpk_knobs[v->knobidx].elname);
  *      return 1;
  *    }
  *
@@ -1026,7 +1026,7 @@ madx_mpk_run(struct in_cmd* cmd)
 
     if (geterrorflag())
     {
-      error("Matching With Knobs","PTC calculation ended with an error. Check your setting and matching limits.");
+      mad_error("Matching With Knobs","PTC calculation ended with an error. Check your setting and matching limits.");
       pro_input_(ptcend);
       goto cleaning;
     }
@@ -1333,14 +1333,14 @@ madx_mpk_addvariable(struct in_cmd* cmd)
   initialpar = command_par_string("initial",cmd->clone);
   if (( ename == 0x0 ) && ( initialpar == 0x0 ))
   {
-    error("matchknobs.c: madx_mpk_addvariable",
+    mad_error("matchknobs.c: madx_mpk_addvariable",
           "Neither element nor initial parameter specified. Command ignored!");
     return;
   }
 
   if ( ename && initialpar)
   {
-    error("matchknobs.c: madx_mpk_addvariable",
+    mad_error("matchknobs.c: madx_mpk_addvariable",
           "Single command may define only one of two, field component or initial parameter. Command ignored!");
     return;
   }
@@ -1350,7 +1350,7 @@ madx_mpk_addvariable(struct in_cmd* cmd)
 
   if ( ename && (kn >= 0) && (ks >=0) )
   {
-    error("matchknobs.c: madx_mpk_addvariable",
+    mad_error("matchknobs.c: madx_mpk_addvariable",
           "Single command may define only one field component, not ks and kn together. Command ignored.");
     return;
   }
@@ -1361,7 +1361,7 @@ madx_mpk_addvariable(struct in_cmd* cmd)
 
   if (knobidx < 0)
   {
-    error("madx_mpk_addvariable","Error occured while adding this variable.");
+    mad_error("madx_mpk_addvariable","Error occured while adding this variable.");
     return;
   }
 


### PR DESCRIPTION
This fixes a crash that occurs when linking madx dynamically to other applications. In this case, on linux the `error` function from `mad_err.c` will be interposed by [error(3)](https://linux.die.net/man/3/error) from the C stdlib (or vice versa, depending on the link order) which leads to segfaults once it is called - because the two function signatures differ.

If you don't like the rename, it could alternatively be solved by setting `__attribute__ ((visibility ("hidden")))` for `error`, but I think the better solution is to avoid the symbol collision altogether, which will also prevent any confusion if `<error.h>` is ever needed in madx.