### PR TITLE
Fix broken URLs in the documentation of MATCH.

### DIFF
--- a/doc/latexuguide/match.tex
+++ b/doc/latexuguide/match.tex
@@ -859,86 +859,94 @@ ENDMATCH;
 
 All matching examples and the related files for executing the \madx
 sample jobs can be found in the examples directory
-(\href{http://cern.ch/madx/madX/examples}{http://cern.ch/madx/madX/examples})
-of the \madx webiste.
-  
+(\href{https://github.com/MethodicalAcceleratorDesign/madx-examples}{https://github.com/MethodicalAcceleratorDesign/madx-examples})
+of the \madx website.
+
 \begin{itemize}
    \item Simple Periodic Cell\\
-     Match a simple cell to given phase advances: 
-     \href{http://cern.ch/madx/madX/examples/match/5cell/job.5cell.madx}{FIVE-CELL}
+     Match a simple cell to given phase advances:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/5cell/job.5cell.madx}
+     {FIVE-CELL}
      
    \item Simple Periodic Cell\\
      Match the matrix elements of the linear transfer matrix at the
-     end of a sequence 5 periodic cells:  
-     \href{http://cern.ch/madx/madX/examples/match/r-matrix/job.r-matrix.madx}{RMATRIX}
+     end of a sequence 5 periodic cells:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/r-matrix/job.r-matrix.madx}
+     {RMATRIX}
      
    \item Transfer line with initial conditions\\
      Match a sequence of 5 periodic cells with initial conditions  to
-     given beta-functions at the end of the sequence:  
-     \href{http://cern.ch/madx/madX/examples/match/line/job.line.madx}{Transfer line}
+     given beta-functions at the end of the sequence:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/line/job.line.madx}
+     {Transfer line}
      
    \item Global tune matching in a sequence of 5 periodic cells \\
-     Match the global tune of a sequence of 5 periodic cells: 
-     \href{http://cern.ch/madx/madX/examples/match/global-tune/job.global-tune.madx}{Global tune}
+     Match the global tune of a sequence of 5 periodic cells:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/global-tune/job.global-tune.madx}
+     {Global tune}
      
    \item Global tune matching for the LHC\\
-     Match the global tune for beam1 of the LHC: 
-     \href{http://cern.ch/madx/madX/examples/match/lhc.tune/job.lhc.tune.madx}{Global tune for the LHC}
+     Match the global tune for beam1 of the LHC:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/lhc.tune/job.lhc.tune.madx}
+     {Global tune for the LHC}
      
    \item Global chromaticity matching for the LHC\\
-     Match the global chromaticity for beam1 of the LHC: 
-     \href{http://cern.ch/madx/madX/examples/match/lhc.chromaticity/job.lhc.chromaticity.madx}{Global
-       chromaticity for the LHC} 
+     Match the global chromaticity for beam1 of the LHC:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/lhc.chromaticity/job.lhc.chromaticity.madx}
+     {Global chromaticity for the LHC}
      
    \item Global chromaticity matching for both beams of the LHC\\
-     Match the global chromaticity for beam1 and beam2 of the LHC: 
-     \href{http://cern.ch/madx/madX/examples/match/lhc.2chromaticity/job.lhc.2chromaticity.madx}{Global
-       chromaticity for both beams of the LHC} 
+     Match the global chromaticity for beam1 and beam2 of the LHC:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/lhc.2chromaticity/job.lhc.2chromaticity.madx}
+     {Global chromaticity for both beams of the LHC}
      
    \item IR8 insertion matching for beam1 of the LHC\\
      Match the insertion IR8 with initial conditions to given values
-     of the optics  functions at the IP and the end of the insertion:  
-     \href{http://cern.ch/madx/madX/examples/match/lhc.insertion/job.lhc.insertion.madx}{IR8
-       insertion matching} for beam1 of the LHC 
+     of the optics  functions at the IP and the end of the insertion:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/lhc.insertion/job.lhc.insertion.madx}
+     {IR8 insertion matching} for beam1 of the LHC
      
    \item IR8 insertion matching for beam1 of the LHC with upper
-     limits on the optics functions\\ 
+     limits on the optics functions\\
      Match the insertion IR8 with initial conditions to given values
      of the optics  functions at the IP and the end of the insertion
      while limiting the maximum acceptable beta functions over the
-     whole insertion:  
-     \href{http://cern.ch/madx/madX/examples/match/lhc.insertion-upper/job.lhc.insertion-upper.madx}{IR8
-       insertion matching} for beam1 of the LHC with upper limits for
-     all beta functions inside the insertion 
+     whole insertion:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/lhc.insertion-upper/job.lhc.insertion-upper.madx}
+     {IR8 insertion matching}
+     for beam1 of the LHC with upper limits for
+     all beta functions inside the insertion
      
    \item Simultaneous orbit matching at IP8 for beam1 and beam2 of
-     the LHC\\ 
+     the LHC\\
      Match simultaneously the orbit of beam1 and beam of the LHC at
-     IP8  with initial conditions to the same given values at the IP:  
-     \href{http://cern.ch/madx/madX/examples/match/lhc.iporbit/job.lhc.iporbit.madx}{Orbit
-       matching at IP8} for beam1 and beam2 of the LHC 
+     IP8  with initial conditions to the same given values at the IP:
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/lhc.iporbit/job.lhc.iporbit.madx}
+     {Orbit matching at IP8} for beam1 and beam2 of the LHC
      
    \item IR8 beta squeeze for beam1 using JACOBIAN matching routine\\
-     Try to find a beta squeeze for IR8 starting from 10 meters. 
-     \href{http://cern.ch/madx/madX/examples/match/lhcV65.ir8squeeze/job.lhcV65.ir8squeeze.madx}{Beta
-       squeeze for IR8} 
+     Try to find a beta squeeze for IR8 starting from 10 meters.
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/lhcV65.ir8squeeze/job.lhcV65.ir8squeeze.madx}
+     {Beta squeeze for IR8}
      
    \item Matching first and second order chromaticity of the LHC
      using USE\_MACRO option. \\
      Match simultaneously the first and second order chromaticity by
      defining macros which compute them using the TWISS command or
-     PTC.  
-     \href{http://cern.ch/madx/madX/examples/match/lhc.qpp/job.lhc.qpp.madx}{Second
-       order chromaticity} 
+     PTC.
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/lhc.qpp/job.lhc.qpp.madx}
+     {Second order chromaticity}
      
    \item Matching s position using VLENGTH flag.\\
      match the positions of elements and the total sequence length
-     for a simple sample sequence.  
-     \href{http://cern.ch/madx/madX/examples/match/s-match/job.s-match.madx}{s position matching}
+     for a simple sample sequence.
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/s-match/job.s-match.madx}
+     {s position matching}
      
    \item Matching s position using USE\_MACRO.\\
-     match the positions of elements and the total sequence length for a simple sample sequence using USE\_MACRO. 
-     \href{http://cern.ch/madx/madX/examples/match/s-match-usemacro/job.s-match-usemacro.madx}{s position matching}
+     match the positions of elements and the total sequence length for a simple sample sequence using USE\_MACRO.
+     \href{https://github.com/MethodicalAcceleratorDesign/madx-examples/blob/master/match/s-match-usemacro/job.s-match-usemacro.madx}
+     {s position matching}
      
 \end{itemize}
 


### PR DESCRIPTION
They pointed to some non-existent place on the MadX website, now they rather point to the madx-examples repository on GitHub.