### PR TITLE
Fix selecting within only a single sequence

### DIFF
--- a/src/mad_select.c
+++ b/src/mad_select.c
@@ -17,7 +17,7 @@ start_iter_select(struct command* cmd, struct sequence_list* sequs, struct seque
 {
   const char* name;
 
-  if (!sequs)
+  if (!sequs && !sequ)
     sequs = sequences;
 
   if (sequs && !sequ && (name = command_par_string("sequence", cmd))) {


### PR DESCRIPTION
Fixes a bug I introduced that will try to select on many sequences even it should only select on one, e.g. when specifying a `CONSTRAINT` within `MATCH` that should apply only to a specific sequence. This would typically result in lots of warnings about elements not being found (in the other sequence), and only shows up when there are multiple sequences defined.