### PR TITLE
Touchek lifetime

### DIFF
--- a/src/touschek.f90
+++ b/src/touschek.f90
@@ -295,8 +295,8 @@ subroutine cavtouschek (um,uloss,iflag)
      if (cos(phirf) .lt. 0) vrf = -vrf
      eta = alfa - one / gammas**2
      if (uloss .ne. zero) then
-        qover = qover + charge * rfv/uloss
-        vrfsum = vrfsum + charge * rfv/harmonl
+        qover = qover +  rfv/uloss
+        vrfsum = vrfsum +  rfv !Charge is not inccluded sine it is not used in twiss or track for the rf-cavity 
         harmonlm = min(harmonl, harmonlm)
      else
         umt = umt + (two * c0) / (harmonl * eta * pi)
@@ -307,8 +307,10 @@ subroutine cavtouschek (um,uloss,iflag)
 11 if (advance_node().ne.0)  goto 10
 
   if (uloss.ne.zero) then
-     fq = two * (sqrt(one - one/qover**2) * vrfsum * harmonlm - uloss * acos(one/qover))
-     um = ten3m / (harmonlm * eta * pi) * fq / (pc * (one + deltap))
+      ! C. Steier, et al., "Measuring and optimizing the momentum aperture in a particle accelerator"
+      ! https://journals.aps.org/pre/pdf/10.1103/PhysRevE.65.056506 
+     fq = (two*uloss)*(sqrt(qover**2 - one) - acos(one/qover))
+     um = fq*ten3m/(pi*alfa*harmonlm*(pc*(one+deltap)/beta))
   else
      um = umt
   endif

--- a/src/touschek.f90
+++ b/src/touschek.f90
@@ -296,7 +296,7 @@ subroutine cavtouschek (um,uloss,iflag)
      eta = alfa - one / gammas**2
      if (uloss .ne. zero) then
         qover = qover +  rfv/uloss
-        vrfsum = vrfsum +  rfv !Charge is not inccluded sine it is not used in twiss or track for the rf-cavity 
+        vrfsum = vrfsum +  rfv/harmonl !Charge is not inccluded sine it is not used in twiss or track for the rf-cavity 
         harmonlm = min(harmonl, harmonlm)
      else
         umt = umt + (two * c0) / (harmonl * eta * pi)
@@ -309,8 +309,9 @@ subroutine cavtouschek (um,uloss,iflag)
   if (uloss.ne.zero) then
       ! C. Steier, et al., "Measuring and optimizing the momentum aperture in a particle accelerator"
       ! https://journals.aps.org/pre/pdf/10.1103/PhysRevE.65.056506 
-     fq = (two*uloss)*(sqrt(qover**2 - one) - acos(one/qover))
-     um = fq*ten3m/(pi*alfa*harmonlm*(pc*(one+deltap)/beta))
+     !fq = (two*vrfsum)*(sqrt(one - one/qover**2)) - two*uloss*acos(one/qover)
+     fq = two * (sqrt(one - one/qover**2) * vrfsum * harmonlm - uloss * acos(one/qover))
+     um = ten3m / (harmonlm * eta * pi) * fq / (pc * (one + deltap))
   else
      um = umt
   endif

--- a/src/touschek.f90
+++ b/src/touschek.f90
@@ -309,7 +309,6 @@ subroutine cavtouschek (um,uloss,iflag)
   if (uloss.ne.zero) then
       ! C. Steier, et al., "Measuring and optimizing the momentum aperture in a particle accelerator"
       ! https://journals.aps.org/pre/pdf/10.1103/PhysRevE.65.056506 
-     !fq = (two*vrfsum)*(sqrt(one - one/qover**2)) - two*uloss*acos(one/qover)
      fq = two * (sqrt(one - one/qover**2) * vrfsum * harmonlm - uloss * acos(one/qover))
      um = ten3m / (harmonlm * eta * pi) * fq / (pc * (one + deltap))
   else


### PR DESCRIPTION
The problem was that there was a charge that was included in the calculations. This charge would have been correct if MAD-X would need a 180 deg change for positive and negative charged particles but since the acceleration is always in relation to the reference particle this doesn't make sense.

The old values were correct when there was a possessively charged particles but wrong in case of a negatively charged. This also fixes the issue #752 