### PR TITLE
Fix line parsing

### DIFF
--- a/src/mad_eval.c
+++ b/src/mad_eval.c
@@ -286,13 +286,10 @@ pro_input(char* statement)
     {
       if (type == 6)
       {
-        get_bracket_range(&statement[start], '(', ')', &rs, &re);
-        ktmp = re+1;
-        if (re > rs && strchr(&statement[ktmp], ':')) /* formal arg.s */
-        {
-          get_bracket_range(&statement[ktmp], '(', ')', &rs, &re);
-          rs += ktmp; re += ktmp;
-        }
+        /* search parens after formal args:  m(a, b): line=(...); */
+        ktmp = strchr(&statement[start], ':') - &statement[start];
+        get_bracket_range(&statement[start+ktmp], '(', ')', &rs, &re);
+        rs += ktmp; re += ktmp;
       }
       else get_bracket_range(&statement[start], '{', '}', &rs, &re);
       if (re > rs)

--- a/src/mad_parse.c
+++ b/src/mad_parse.c
@@ -101,14 +101,16 @@ in_spec_list(char* string)
   int i = 0, n = imin((int)strlen(string), 100);
   strncpy(c_dum->c, string, n); stolower(c_dum->c);
   supp_char(' ', c_dum->c);
+  char* semicolon = strchr(c_dum->c, ';');
   while (special_comm_cnt[i])
   {
     if (special_comm_desc[i][0] == '>')
     {
       if ((cp = strchr(c_dum->c, special_comm_desc[i][1])) != NULL)
       {
-        if (strncmp(++cp, &special_comm_desc[i][2], special_comm_cnt[i])
-            == 0)  return i+1;
+        if (strncmp(++cp, &special_comm_desc[i][2], special_comm_cnt[i]) == 0
+                && (semicolon == NULL || cp < semicolon))
+            return i+1;
       }
     }
     else if (strncmp(c_dum->c, &special_comm_desc[i][0],special_comm_cnt[i])

--- a/tests/test-line/test-line.madx
+++ b/tests/test-line/test-line.madx
@@ -24,4 +24,16 @@ T4: LINE=(D1, -3*(Q1), D2);
 Use, sequence=T4;
 Survey, sequence=T4;
 
+! Regression tests:
+
+! This snippet previously resulted in T5 not being defined correctly,
+! leading to the message "++++++ warning: unknown sequence skipped: t5":
+kappa=0; T5: LINE=(D1);
+Use, sequence=T5;
+
+! This snippet previously resulted in the `kappa=2` statement being ignored,
+! leading to the message "kappa not found":
+D3: drift, L=1; T6: LINE=(D1); kappa=2;
+show, kappa;
+
 Exit;

--- a/tests/test-line/test-line.ref
+++ b/tests/test-line/test-line.ref
@@ -1,9 +1,9 @@
 
   ++++++++++++++++++++++++++++++++++++++++++++
-  +     MAD-X 5.03.07  (64 bit, Darwin)      +
+  +     MAD-X 5.05.02  (64 bit, Linux)       +
   + Support: mad@cern.ch, http://cern.ch/mad +
-  + Release   date: 2017.10.20               +
-  + Execution date: 2017.12.14 18:08:43      +
+  + Release   date: 2019.07.25               +
+  + Execution date: 2019.09.18 03:58:46      +
   ++++++++++++++++++++++++++++++++++++++++++++
 Title, "test of line expansion in MAD-X"; 
 
@@ -123,6 +123,41 @@ Use, sequence=T4;
 TOP Expand_sequence name t4 with length 6.000000e+00, ref_flag 0
 Survey, sequence=T4;
 
+
+
+! Regression tests:
+
+
+
+! This snippet previously resulted in T5 not being defined correctly,
+
+! leading to the message "++++++ warning: unknown sequence skipped: t5":
+
+kappa=0; T5: LINE=(D1);
+
+Use, sequence=T5;
+
+   in get_node_pos: name: t5$start, pos: 0.000000e+00, fact: 0.000000e+00, length: 0.000000e+00, from_name: (null)
+	 in get_node_pos: name: t5$start, from: 0.000000e+00			  ---> final pos: 0.000000e+00 
+   in get_node_pos: name: d1, pos: 5.000000e-01, fact: 0.000000e+00, length: 1.000000e+00, from_name: (null)
+	 in get_node_pos: name: d1, from: 0.000000e+00			  ---> final pos: 5.000000e-01 
+   in get_node_pos: name: t5$end, pos: 1.000000e+00, fact: 0.000000e+00, length: 0.000000e+00, from_name: (null)
+	 in get_node_pos: name: t5$end, from: 0.000000e+00			  ---> final pos: 1.000000e+00 
+
+
+TOP Expand_sequence name t5 with length 1.000000e+00, ref_flag 0
+
+
+! This snippet previously resulted in the `kappa=2` statement being ignored,
+
+! leading to the message "kappa not found":
+
+D3: drift, L=1; T6: LINE=(D1); kappa=2;
+
+++++++ info: kappa redefined
+show, kappa;
+
+kappa               =                  2 ;
 
 
 Exit;


### PR DESCRIPTION
Fixes two parsing/evaluation bugs that occur when writing multiple statements on the same line involving a `LINE()` definition:

```
d: drift; myline: line=(d); beam;
use, sequence=myline;

-> +=+=+= fatal: USE - sequence without beam: myline
```

and:

```
kappa=0; myline: line=(drift);
beam;
use, sequence=myline;

-> ++++++ warning: unknown sequence skipped: myline
```

Note: these bug trigger whenever all statements are passed in the same `pro_input` call. This typically happens while reading from input files if they are on the same line, but also if they are within the same if/while construct, or if `pro_input` is called with text directly for some other reason, i.e:

```
if (1 == 1) {
  d: drift;
  myline: line=(d);
  beam;
}
use, sequence=myline;
```

and:

```
if (1 == 1) {
  kappa=0;
  myline: line=(drift);
}
beam;
use, sequence=myline;
```

give the same errors.