### PR TITLE
Fix seg fault weights

### DIFF
--- a/doc/latexuguide/match.tex
+++ b/doc/latexuguide/match.tex
@@ -747,7 +747,7 @@ USE_MACRO, NAME=macro1;
      or
 macro1: MACRO={ ... madx statements};
 CONSTRAINT, expr=  "lhs1 < | = | > rhs1";
-CONSTRAINT, expr=  "lhs2 < | = | > rhs2";
+CONSTRAINT, weight=2, expr=  "lhs2 < | = | > rhs2";
 ...  CONSTRAINT statements ...
 MACRO 2 definition
 ... CONSTRAINT statements ...

--- a/src/mad_match.c
+++ b/src/mad_match.c
@@ -925,6 +925,10 @@ match_weight(struct in_cmd* cmd)
 {
   struct name_list* nl = cmd->clone->par_names;
   struct command_parameter_list* plc = cmd->clone->par;
+  if(current_weight==NULL) {
+    warning("WEIGHTS have to be given at the CONSTRAINT command when using: ", "MACRO");
+    return;
+  }
   struct command_parameter_list* pl = current_weight->par;
   int j;
   for (j = 0; j < pl->curr; j++)
@@ -936,6 +940,7 @@ match_weight(struct in_cmd* cmd)
     }
   }
 }
+
 
 // public interface
 


### PR DESCRIPTION
Just prevents from segmentation fault when inputting weights made for "normal" matching when using: USE_MACRO