### PR TITLE
Fix ignored step size in matching (do not merge yet)

### DIFF
--- a/src/mad_match.c
+++ b/src/mad_match.c
@@ -1039,7 +1039,7 @@ next_vary(char* name, int* name_l, double* lower, double* upper, double* step, i
   strfcpy(name, v_name, *name_l);
   *lower = command_par_value("lower", comm);
   *upper = command_par_value("upper", comm);
-  if ((l_step = command_par_value("step", comm)) < ten_m_12) l_step = ten_m_12;
+  if ((l_step = command_par_value("step", comm)) < ten_m_12) l_step = 1e-8;
   *step = l_step;
   *slope = command_par_value("slope", comm);
   *opt = command_par_value("opt", comm);

--- a/src/matchjc.f90
+++ b/src/matchjc.f90
@@ -59,7 +59,7 @@
         if (strategy .ge. 1) then
 !          calls=0
           call jacob(mtfcn,ncon,nvar,strategy,calls,call_lim,           &
-     &vect,fun_vec,tol,                                                 &
+     &vect,dvect,fun_vec,tol,                                                 &
      &w_ifjac,w_iwa4,                                                   &
      &xstart,xold,cool,balance,random,bisec,cond,match_mode)
         endif
@@ -68,7 +68,7 @@
 
 
       subroutine jacob(fcn,m,n,strategy,calls,call_lim,                 &
-     &x,fvec,epsfcn,                                                    &
+     &x,dvect,fvec,epsfcn,                                                    &
      &fjac,wa4,                                                         &
      &xstart,xold,cool,balance,random,bisec,cond,match_mode)
 
@@ -104,7 +104,7 @@
       double precision ftol,gtol
       double precision dxnorm,xnorm,dx(n),fmin_start,fmin_old2
       double precision vdot
-      double precision xtol,x(n),xstart(n),xold(n),fvec(m)
+      double precision xtol,x(n),xstart(n),xold(n),fvec(m), dvect(n)
       double precision xopt(n),xbest(n),fminbest,condnum
       double precision fjac(m,n),wa4(m),zero,one,two
       double precision epsil,epsmch,cool,balance,random
@@ -188,7 +188,7 @@
       ireset=0
 
 !---- Calculate the jacobian
-      call fdjac2(fcn,m,n,x,fvec,fjac,m,iflag,xtol,wa4)
+      call fdjac2(fcn,m,n,x,fvec,fjac,m,iflag,xtol,wa4, dvect)
 
       if (strategy.eq.2) then
 !        call DGESDD('A',M,N,fjac,M,SV,U,M,VT,N,                         &

--- a/tests/test-match-3/test-match-3.madx
+++ b/tests/test-match-3/test-match-3.madx
@@ -21,9 +21,9 @@ twiss, sequence=fivecell;
 
 match,sequence=fivecell,beta0=abc,x=0,px=0,y=0,py=0,t=0,pt=0;
 constraint,sequence=fivecell,range=#e,betx=180.0,bety=30.0;
-vary,name=kqf,step=1.0e-6;
-vary,name=kqd,step=1.0e-6;
-lmdif,calls=500,tolerance=1.e-15;
+vary,name=kqf;
+vary,name=kqd,step=8.0e-6;
+jacobian,calls=500,tolerance=1.e-15;
 endmatch;
 
 value, kqf;

--- a/tests/test-match-3/test-match-3.madx
+++ b/tests/test-match-3/test-match-3.madx
@@ -21,9 +21,9 @@ twiss, sequence=fivecell;
 
 match,sequence=fivecell,beta0=abc,x=0,px=0,y=0,py=0,t=0,pt=0;
 constraint,sequence=fivecell,range=#e,betx=180.0,bety=30.0;
-vary,name=kqf;
-vary,name=kqd,step=8.0e-6;
-jacobian,calls=500,tolerance=1.e-15;
+vary,name=kqf,step=1.0e-6;
+vary,name=kqd,step=1.0e-6;
+lmdif,calls=500,tolerance=1.e-15;
 endmatch;
 
 value, kqf;


### PR DESCRIPTION
This step size was previously ignored in matching as described in #702 . This PR fixes this but the tests are not updated and checked. 