### PR TITLE
Spatial coordinates in thin-cf

### DIFF
--- a/src/trrun.f90
+++ b/src/trrun.f90
@@ -1106,7 +1106,7 @@ end SUBROUTINE ttmult_cf_mini
 
 SUBROUTINE  ttmult_cf(track,ktrack,dxt,dyt,turn, thin_foc)
   use twtrrfi
-  use twissbeamfi, only : deltap, beta
+  use twissbeamfi, only : beta
   use math_constfi, only : zero, one, two, three
   use time_varfi
   use trackfi
@@ -1185,9 +1185,9 @@ SUBROUTINE  ttmult_cf(track,ktrack,dxt,dyt,turn, thin_foc)
   lambda(0:maxmul) = 0
 
   if (elrad.gt.zero) then
-    lambda(0) = (normal(0) + (0, 1)*skew(0))/elrad/(one + deltap)
+    lambda(0) = (normal(0) + (0, 1)*skew(0))/elrad
      do k = 1, nord
-        lambda(k) = (f_errors(2*k) + (0, 1)*f_errors(2*k+1))/elrad/Factorial(k)/(one + deltap)
+        lambda(k) = (f_errors(2*k) + (0, 1)*f_errors(2*k+1))/elrad/Factorial(k)
      enddo
   else
      lambda = zero
@@ -1224,8 +1224,6 @@ SUBROUTINE  ttmult_cf(track,ktrack,dxt,dyt,turn, thin_foc)
 
   do jtrk = 1, ktrack
      etahat = sqrt(two*track(6,jtrk)/beta + track(6,jtrk)**2 + one) - one ! etahat = deltap of individual particle
-     etahat = etahat + deltap ! take derivative with respect to a point having a deltap-offset, approximately maintaining
-                              ! the fixed reference orbit in MAD-X.
      h0 = sqrt((one + etahat)**2 - track(2,jtrk)**2 - track(4,jtrk)**2)
 
      rp = (track(1,jtrk) + (0, 1)*track(3,jtrk))/two

--- a/src/trrun.f90
+++ b/src/trrun.f90
@@ -1136,7 +1136,7 @@ SUBROUTINE  ttmult_cf(track,ktrack,dxt,dyt,turn, thin_foc)
   integer :: nord, k, j, nn, ns, bvk, iord, n_ferr, jtrk, nd
   integer, external :: Factorial
   double precision :: dpx, dpy, tilt, kx, ky, elrad, bp1, h0
-  double precision :: dtmp, an, angle, tilt2
+  double precision :: dtmp, an, angle, tilt2, etahat
   double precision :: normal(0:maxmul), skew(0:maxmul), f_errors(0:maxferr)
   double complex :: kappa, barkappa, sum0, del_p_g, pkick, dxdpg, dydpg, &
                     dxx, dxy, dyy, rp, rm
@@ -1222,7 +1222,12 @@ SUBROUTINE  ttmult_cf(track,ktrack,dxt,dyt,turn, thin_foc)
      g(k + 1, k + 1) = conjg(g(k + 1, 0))
   enddo
 
-   do jtrk = 1,ktrack
+  do jtrk = 1, ktrack
+     etahat = sqrt(two*track(6,jtrk)/beta + track(6,jtrk)**2 + one) - one ! etahat = deltap of individual particle
+     etahat = etahat + deltap ! take derivative with respect to a point having a deltap-offset, approximately maintaining
+                              ! the fixed reference orbit in MAD-X.
+     h0 = sqrt((one + etahat)**2 - track(2,jtrk)**2 - track(4,jtrk)**2)
+
      rp = (track(1,jtrk) + (0, 1)*track(3,jtrk))/two
      rm = conjg(rp)
 
@@ -1236,15 +1241,16 @@ SUBROUTINE  ttmult_cf(track,ktrack,dxt,dyt,turn, thin_foc)
         del_p_g = del_p_g + sum0
      enddo
      ! Now compute kick (Eqs. (38) in Ref. above)
-     pkick = elrad*(barkappa*(one + deltap) + del_p_g)
+     pkick = elrad*(barkappa*h0 + del_p_g)
      dpx = real(pkick)
      dpy = - aimag(pkick)
-     track(2,jtrk) = track(2,jtrk) + dpx
-     track(4,jtrk) = track(4,jtrk) + dpy
+     track(1, jtrk) = track(1, jtrk) + elrad*(kx*track(1, jtrk) + ky*track(3, jtrk))*track(2, jtrk)/h0
+     track(2, jtrk) = track(2, jtrk) + dpx
+     track(3, jtrk) = track(3, jtrk) + elrad*(kx*track(1, jtrk) + ky*track(3, jtrk))*track(4, jtrk)/h0
+     track(4, jtrk) = track(4, jtrk) + dpy
      ! N.B. orbit(5) = \sigma/beta and orbit(6) = beta*p_\sigma
-     track(5,jtrk) = track(5,jtrk) - elrad*(kx*track(1,jtrk) + ky*track(3,jtrk)) &
-                *(one + beta*track(6,jtrk))/(one + deltap)/beta
-  
+     track(5, jtrk) = track(5, jtrk) - elrad*(kx*track(1, jtrk) + ky*track(3, jtrk)) &
+                *(one + beta*track(6, jtrk))/beta/(one + etahat)
   enddo
 
 

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -4286,8 +4286,6 @@ SUBROUTINE tmmult_cf_short(fsec, ftrk, orbit, fmap, re, te)
   !
   ! play the role as the k'th skew- and normal field component.
 
-  deltap = deltap/beta ! get the MAD-X definition of chromaticity
-
   do k = 0, nord
      ! The factor (one + deltap) below is taken from the original MAD-X routine.
      lambda(k) = (f_errors(2*k) + (0, 1)*f_errors(2*k+1))/elrad/Factorial(k)/(one + deltap)
@@ -4530,8 +4528,6 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
   ! Re[\lambda_k] = 1/k! \partial^k B_y / \partial_r^k |_{\varphi = tilt} .
   !
   ! play the role as the k'th skew- and normal field component.
-
-  deltap = deltap/beta ! get the MAD-X definition of chromaticity
 
   do k = 0, nord
      ! The factor (one + deltap) below is taken from the original MAD-X routine.

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -4201,7 +4201,7 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
   integer :: nord, k, j, nn, ns, bvk, iord, n_ferr
   integer, external :: Factorial
   double precision :: dpx, dpy, tilt, kx, ky, elrad, bp1
-  double precision :: an, angle, dtmp, h0, etahat, ux, uy, xi, eta
+  double precision :: an, angle, dtmp, h0, etahat
   double precision :: normal(0:maxmul), skew(0:maxmul), f_errors(0:maxferr)
   double precision :: orbit(6), re(6,6), te(6,6,6), tilt2
   double complex :: kappa, barkappa, sum0, del_p_g, pkick, dxdpg, dydpg, &
@@ -4224,7 +4224,8 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
   F_ERRORS(0:maxferr) = zero
   n_ferr = node_fd_errors(f_errors)
   bvk = node_value('other_bv ')
-  tilt2 = 0 !This is a dumy parameter now that can be changed to have a relative tilt of the different orders
+  tilt2 = 0 ! A parameter describing the relative tilt between
+            ! the dipole component and the higher-order components of the CFM
 
   !####SETTING UP THE MULTIPLES
   an = node_value('angle ')
@@ -4236,9 +4237,9 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
   ! that loop should start at one since nominal dipole strength already taken into account above
   !needs to be here though
   do iord = 0, max(nn, ns, n_ferr/2-1)
- !    get the maximum effective order; loop runs over maximum of user given values
+  !    get the maximum effective order; loop runs over maximum of user given values
      if (f_errors(2*iord).ne.zero .or. f_errors(2*iord+1).ne.zero .or. &
-          normal(iord).ne.zero .or. skew(iord).ne.zero) nord = iord+1 !  why  +1
+          normal(iord).ne.zero .or. skew(iord).ne.zero) nord = iord + 1 !  why  +1
   enddo
 
   do iord = 1, nord
@@ -4336,9 +4337,7 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
         del_p_g = del_p_g + sum0
      enddo
      ! Now compute kick (Eqs. (38) in Ref. above)
-
-     !pkick = elrad*(barkappa*(one + deltap) + del_p_g) ! original version
-     pkick = elrad*(barkappa*h0 + del_p_g) ! new version
+     pkick = elrad*(barkappa*h0 + del_p_g)
 
      dpx = real(pkick)
      dpy = - aimag(pkick)
@@ -4349,7 +4348,7 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
      orbit(4) = orbit(4) + dpy
      ! N.B. orbit(5) = \sigma/beta and orbit(6) = beta*p_\sigma
      orbit(5) = orbit(5) - elrad*(kx*orbit(1) + ky*orbit(3)) &
-                *(one + beta*orbit(6))/beta/(one + etahat) ! 1/(one + deltap)  original version
+                *(one + beta*orbit(6))/beta/(one + etahat)
   endif
   ! First-order terms by derivation of Eqs. (39) in Ref. above, at zero
   ! re(6,6) is assumed to be a unit matrix as input

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -4390,10 +4390,8 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
 
      bp1 = one - one/beta**2
 
-     !te(1, 1, 2) = elrad*kx/(one + deltap)/two ! factor 1/two: see comment above
      te(1, 1, 2) = elrad*kx*(one/h0 + orbit(2)**2/h0**3)/two
      te(1, 2, 1) = te(1, 1, 2)
-     !te(1, 2, 3) = elrad*ky/(one + deltap)/two ! factor 1/two: see comment above
      te(1, 2, 3) = elrad*ky*(one/h0 + orbit(2)**2/h0**3)/two
      te(1, 3, 2) = te(1, 2, 3)
 

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -3409,6 +3409,7 @@ SUBROUTINE tmmap(code,fsec,ftrk,orbit,fmap,ek,re,te,fcentre,dl)
 
      case (code_multipole)
         if(get_option('thin_cf ').ne.zero .and. node_value('lrad ') .gt. zero) then
+          !call tmmult_cf_short(fsec,ftrk,orbit,fmap,re,te)
           call tmmult_cf(fsec,ftrk,orbit,fmap,re,te)
         else
           call tmmult(fsec,ftrk,orbit,fmap,re,te)
@@ -4177,7 +4178,7 @@ INTEGER FUNCTION Factorial(n)
   Factorial = Ans
 END FUNCTION Factorial
 
-SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
+SUBROUTINE tmmult_cf_short(fsec, ftrk, orbit, fmap, re, te)
   use twtrrfi, only : maxmul, maxferr
   use twissbeamfi, only : deltap, beta
   use math_constfi, only : zero, one, two, three
@@ -4196,6 +4197,12 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
   !     te(6,6,6) (double)  second-order terms.                          *
   !     Detailed description:                                            *
   !     See Phys. Rev. AccelBeams 19.054002 by M.Titze                   *
+  !                                                                      *
+  !     Note:                                                            *
+  !     This 'short' version yields the correct chromaticity of a        *
+  !     sliced sector CFM only if TWISS is used without the 'chrom'      *
+  !     option. For a correct treatment of the chrom option,             * 
+  !     tmmult_cf must be used.                                     *
   !----------------------------------------------------------------------*
   logical :: fsec, ftrk, fmap
   integer :: nord, k, j, nn, ns, bvk, iord, n_ferr
@@ -4279,6 +4286,8 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
   !
   ! play the role as the k'th skew- and normal field component.
 
+  deltap = deltap/beta ! get the MAD-X definition of chromaticity
+
   do k = 0, nord
      ! The factor (one + deltap) below is taken from the original MAD-X routine.
      lambda(k) = (f_errors(2*k) + (0, 1)*f_errors(2*k+1))/elrad/Factorial(k)/(one + deltap)
@@ -4287,13 +4296,17 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
   ! Set the curvature of the MAD-X reference trajectory; Due to MAD-X standards,
   ! this trajectory should be independent on deltap
   if (an .eq. 0) then
-     ! The special case an == 0 is also treated differently for backward compatibility
+     ! The special case an == 0 is treated differently for the purpose of backwards compatibility
      kx = real(lambda(0))*(one + deltap)
      ky = -aimag(lambda(0))*(one + deltap)
   else
-     kx = an/elrad*cos(tilt) !  N.B. B_y |_{\varphi = tilt, r = 0} = kx
-     ky = an/elrad*sin(tilt) !       B_x |_{\varphi = tilt, r = 0} = -ky, see Eqs. (18) in
-  endif                      ! Phys. Rev. AccelBeams 19.054002
+     kx = an/elrad*cos(tilt)
+     ky = an/elrad*sin(tilt)
+  endif
+
+  !  N.B. B_y |_{\varphi = tilt, r = 0} = kx
+  !       B_x |_{\varphi = tilt, r = 0} = -ky, see Eqs. (18) in
+  ! Phys. Rev. AccelBeams 19.054002
 
   kappa = kx + (0, 1)*ky
   barkappa = conjg(kappa)
@@ -4345,11 +4358,12 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
      orbit(4) = orbit(4) + dpy
      ! N.B. orbit(5) = \sigma/beta and orbit(6) = beta*p_\sigma
      orbit(5) = orbit(5) - elrad*(kx*orbit(1) + ky*orbit(3)) &
-                *(one + beta*orbit(6))/beta/(one + etahat)
+                *(one + beta*orbit(6))/beta/h0
   endif
   ! First-order terms by derivation of Eqs. (39) in Ref. above, at zero
   ! re(6,6) is assumed to be a unit matrix as input
-  ! Eq. (2.38) are required to obtain agreement to the thick sectormap.
+  ! Eqs. (39) are required to obtain agreement to the thick sectormap.
+
   if (nord .ge. 1) then
      ! The next two expressions emerge by the first
      ! derivative of \partial_+ G wrt. x and y, see documentation.
@@ -4404,6 +4418,418 @@ SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
      te(5, 3, 6) = - te(1, 2, 3)*bp1
      te(5, 6, 1) = - te(1, 1, 2)*bp1
      te(5, 6, 3) = - te(1, 2, 3)*bp1
+  endif
+end SUBROUTINE tmmult_cf_short
+
+SUBROUTINE tmmult_cf(fsec, ftrk, orbit, fmap, re, te)
+  use twtrrfi, only : maxmul, maxferr
+  use twissbeamfi, only : deltap, beta
+  use math_constfi, only : zero, one, two, three
+  implicit none
+  !----------------------------------------------------------------------*
+  !     Purpose:                                                         *
+  !     Computes thin-lens kick through combined-function magnet.        *
+  !     Input:                                                           *
+  !     fsec      (logical) if true, return second order terms.          *
+  !     ftrk      (logical) if true, track orbit.                        *
+  !     Input/output:                                                    *
+  !     orbit(6)  (double)  closed orbit.                                *
+  !     Output:                                                          *
+  !     fmap      (logical) if true, element has a map.                  *
+  !     re(6,6)   (double)  transfer matrix.                             *
+  !     te(6,6,6) (double)  second-order terms.                          *
+  !     Detailed description:                                            *
+  !     See Phys. Rev. AccelBeams 19.054002 by M.Titze                   *
+  !     Implementation of full map (Eq. (2.38))                          *
+  !----------------------------------------------------------------------*
+  logical :: fsec, ftrk, fmap
+  integer :: nord, k, j, nn, ns, bvk, iord, n_ferr
+  integer, external :: Factorial
+  double precision :: dpx, dpy, tilt, kx, ky, elrad, bp1, etahat, h0
+  double precision :: an, angle, dtmp
+  double precision :: normal(0:maxmul), skew(0:maxmul), f_errors(0:maxferr)
+  double precision :: orbit(6), re(6,6), te(6,6,6), tilt2
+  double complex :: kappa, barkappa, sum0, del_p_g, pkick, dxdpg, dydpg, &
+                    dxx, dxy, dyy, rp, rm
+  double complex :: lambda(0:maxmul)
+  double complex :: g(0:maxmul, 0:maxmul)
+
+  double complex :: sigma(0:maxmul, 0:maxmul), &
+                    dxsigma(0:maxmul, 0:maxmul), &
+                    dysigma(0:maxmul, 0:maxmul), &
+                    dxxsigma(0:maxmul, 0:maxmul), &
+                    dxysigma(0:maxmul, 0:maxmul), &
+                    dyysigma(0:maxmul, 0:maxmul)
+
+  double precision, external :: node_value
+  integer, external :: node_fd_errors
+  fmap = .true.
+
+  ! Read magnetic field components & fill lambda's according to field
+  ! components relative to given plane
+  normal = zero ; call get_node_vector('knl ', nn, normal)
+  skew   = zero ; call get_node_vector('ksl ', ns, skew)
+  nord = max(nn, ns)
+  tilt = node_value('tilt ')
+  elrad = node_value('lrad ')
+
+  F_ERRORS(0:maxferr) = zero
+  n_ferr = node_fd_errors(f_errors)
+  bvk = node_value('other_bv ')
+  tilt2 = 0 ! A parameter describing the relative tilt between
+            ! the dipole component and the higher-order components of the CFM
+
+  !####SETTING UP THE MULTIPOLES
+  an = node_value('angle ')
+  f_errors(0) = f_errors(0) + normal(0) ! The zero-component of the B-field
+
+  !Below here should not be commented output
+  !---- Other components and errors.
+  nord = 0
+  ! that loop should start at one since nominal dipole strength already taken into account above
+  !needs to be here though
+  do iord = 0, max(nn, ns, n_ferr/2-1)
+  !   get the maximum effective order; loop runs over maximum of user given values
+     if (f_errors(2*iord).ne.zero .or. f_errors(2*iord+1).ne.zero .or. &
+          normal(iord).ne.zero .or. skew(iord).ne.zero) nord = iord+1 !  why  +1
+  enddo
+
+  do iord = 1, nord
+     f_errors(2*iord)   = (normal(iord) + f_errors(2*iord))
+     f_errors(2*iord+1) = (skew(iord)   + f_errors(2*iord+1))
+     if (tilt .ne. zero) then
+        if (f_errors(2*iord).ne.zero .or. f_errors(2*iord+1).ne.zero) then
+           angle = atan2(f_errors(2*iord+1), f_errors(2*iord)) / (iord+1) - tilt
+        else
+           angle = -tilt
+        endif
+        angle = (iord+1) * angle
+        dtmp = sqrt(f_errors(2*iord)**2 + f_errors(2*iord+1)**2)
+        f_errors(2*iord)   = dtmp * cos(angle)
+        f_errors(2*iord+1) = dtmp * sin(angle)
+     endif
+     f_errors(2*iord)   = bvk * f_errors(2*iord)
+     f_errors(2*iord+1) = bvk * f_errors(2*iord + 1)
+  enddo
+  !Done with all the setting up...
+
+  ! The "normal" components are considered here as the expansion coefficients of
+  ! B_y wrt. the reference plane, while the "skew" components are considered as the
+  ! corresponding expansion coefficients of B_x, see documentation. This can
+  ! be modified in the future, in particular to use tilted components,
+  ! but bare in mind that the bending curvature (the
+  ! lambda(0) terms) should be unchanged.
+  !
+  ! The above means precisely, that we currently implemented the following scheme:
+  !
+  ! B_y |_{\varphi = tilt} + i B_x |_{\varphi = tilt} = \sum_{k = 0}^nord \lambda_k r^k
+  !
+  ! with complex coefficients \lambda_k and in which
+  !
+  ! Im[\lambda_k] = 1/k! \partial^k B_x / \partial_r^k |_{\varphi = tilt} ,
+  ! Re[\lambda_k] = 1/k! \partial^k B_y / \partial_r^k |_{\varphi = tilt} .
+  !
+  ! play the role as the k'th skew- and normal field component.
+
+  deltap = deltap/beta ! get the MAD-X definition of chromaticity
+
+  do k = 0, nord
+     ! The factor (one + deltap) below is taken from the original MAD-X routine.
+     lambda(k) = (f_errors(2*k) + (0, 1)*f_errors(2*k+1))/elrad/Factorial(k)/(one + deltap)
+  enddo
+
+  ! Set the curvature of the MAD-X reference trajectory; Due to MAD-X standards,
+  ! this trajectory should be independent on deltap
+  if (an .eq. 0) then
+     ! The special case an == 0 is treated differently for the purpose of backwards compatibility
+     kx = real(lambda(0))*(one + deltap)
+     ky = -aimag(lambda(0))*(one + deltap)
+  else
+     kx = an/elrad*cos(tilt)
+     ky = an/elrad*sin(tilt)
+  endif
+
+  !  N.B. B_y |_{\varphi = tilt, r = 0} = kx
+  !       B_x |_{\varphi = tilt, r = 0} = -ky, see Eqs. (18) in
+  ! Phys. Rev. AccelBeams 19.054002
+
+  kappa = kx + (0, 1)*ky
+  barkappa = conjg(kappa)
+
+  ! Now fill up the g_{ij}'s for j = 0, ..., i and i = 0, ..., nord + 1.
+  g(0, 0) = (0, 0)
+  g(1, 0) = -lambda(0)
+  g(1, 1) = conjg(g(1, 0))
+
+  do k = 1, nord
+     do j = 0, k - 1
+        ! Eq. (6), in Ref. above
+        g(k + 1, j + 1) = (barkappa*g(k, j + 1)*(j + one)*(j - k + three/two) +  &
+             kappa*g(k, j)*(k - j)*(one/two - j))/(k - j)/(j + one)
+     enddo
+     ! Eq. (8) in Ref. above
+     sum0 = 0
+     do j = 1, k
+       sum0 = sum0 - (k + 1 - j)*g(k + 1, j)*exp(-two*(0, 1)*j*tilt2)
+     enddo
+     g(k + 1, 0) = ( sum0 - two**k*exp(-(0, 1)*k*tilt2)*( lambda(k) &
+                    + one/two*(barkappa*exp((0, 1)*tilt2) + kappa*exp(-(0, 1)*tilt2)) &
+                    *lambda(k - 1) ) )/(k + one)
+     g(k + 1, k + 1) = conjg(g(k + 1, 0))
+  enddo
+
+  etahat = sqrt(two*orbit(6)/beta + orbit(6)**2 + one) - one ! etahat = deltap of individual particle
+  h0 = sqrt((one + etahat)**2 - orbit(2)**2 - orbit(4)**2)
+
+  if (ftrk) then
+     rp = (orbit(1) + (0, 1)*orbit(3))/two
+     rm = conjg(rp)
+     ! Compute \partial_+ G using Eq. (7) in Ref. above
+     del_p_g = 0
+     do k = 1, nord
+        sum0 = 0
+        do j = 0, k - 1
+           sum0 = sum0 + (k - j)*g(k, j)*rp**(k - 1 - j)*rm**j
+        enddo
+        del_p_g = del_p_g + sum0
+     enddo
+     ! Now compute kick (Eqs. (38) in Ref. above)
+     pkick = elrad*(barkappa*h0 + del_p_g)
+     dpx = real(pkick)
+     dpy = - aimag(pkick)
+     orbit(1) = orbit(1) + elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)/h0
+     orbit(2) = orbit(2) + dpx
+     orbit(3) = orbit(3) + elrad*(kx*orbit(1) + ky*orbit(3))*orbit(4)/h0
+     orbit(4) = orbit(4) + dpy
+     ! N.B. orbit(5) = \sigma/beta and orbit(6) = beta*p_\sigma
+     orbit(5) = orbit(5) - elrad*(kx*orbit(1) + ky*orbit(3)) &
+                *(one + beta*orbit(6))/beta/h0
+  endif
+  ! First-order terms by derivation of Eqs. (39) in Ref. above, at zero
+  ! re(6,6) is assumed to be a unit matrix as input
+  ! Eqs. (39) are required to obtain agreement to the thick sectormap.
+
+  if (nord .ge. 1) then
+     ! The next two expressions emerge by the first
+     ! derivative of \partial_+ G wrt. x and y, see documentation.
+     ! the factors (one + deltap) means that we take the derivative with respect to a given
+     ! energy-offset, so that if deltap != 0, the derivative is evaluated at a larger radius.
+
+     do k = 0, nord
+         do j = 0, k
+             ! N.B.: j = k + 1 leads to sigma(k, k + 1) = 0, so the inner loop will go only up to k
+             sigma(k, j) = elrad*(k + one - j)*g(k + 1, j)
+         enddo
+     enddo
+
+     do k = 0, nord - 1
+         do j = 0, k
+             dxsigma(k, j) = ((k + one - j)*sigma(k + 1, j) + (j + one)*sigma(k + 1, j + 1))/two
+             dysigma(k, j) = (0, 1)*((k + one - j)*sigma(k + 1, j) - (j + one)*sigma(k + 1, j + 1))/two
+         enddo
+     enddo
+
+     dxdpg = 0
+     dydpg = 0
+     do k = 0, nord - 1
+         do j = 0, k
+             dxdpg = dxdpg + dxsigma(k, j)*rp**(k - j)*rm**j
+             dydpg = dydpg + dysigma(k, j)*rp**(k - j)*rm**j
+         enddo
+     enddo
+
+     ! if evaluated at zero, one can instead use:
+     !dxdpg = elrad/two*(two*g(2, 0) + g(2, 1))
+     !dydpg = elrad/two*(0, 1)*(two*g(2, 0) - g(2, 1))
+
+     re(1, 1) = one + elrad*kx*orbit(2)/h0
+     re(1, 2) = elrad*(kx*orbit(1) + ky*orbit(3))*(one/h0 + orbit(2)**2/h0**3)
+     re(1, 3) = elrad*ky*orbit(2)/h0
+     re(1, 4) = elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)*orbit(4)/h0**3
+     re(1, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)/h0**3/beta*(one + beta*orbit(6))
+
+     re(2, 1) = real(dxdpg)
+     re(2, 2) = one - elrad*kx*orbit(2)/h0 
+     re(2, 3) = real(dydpg)
+     re(2, 4) = -elrad*kx*orbit(4)/h0 
+     re(2, 6) = elrad*kx/beta*(one + beta*orbit(6))/h0
+
+     re(3, 1) = elrad*kx*orbit(4)/h0
+     re(3, 2) = elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)*orbit(4)/h0**3
+     re(3, 3) = one + elrad*ky*orbit(4)/h0
+     re(3, 4) = elrad*(kx*orbit(1) + ky*orbit(3))*(one/h0 + orbit(4)**2/h0**3)
+     re(3, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))*orbit(4)/h0**3/beta*(one + beta*orbit(6))
+
+     re(4, 1) = - aimag(dxdpg)
+     re(4, 2) = elrad*ky*orbit(2)/h0
+     re(4, 3) = - aimag(dydpg)
+     re(4, 4) = one - elrad*ky*orbit(4)/h0
+     re(4, 6) = elrad*ky/beta*(one + beta*orbit(6))/h0
+
+     re(5, 1) = -elrad*kx/beta*(one + beta*orbit(6))/h0
+     re(5, 2) = -elrad*orbit(2)*(kx*orbit(1) + ky*orbit(3))*(one + beta*orbit(6))/beta/h0**3
+     re(5, 3) = -elrad*ky/beta*(one + beta*orbit(6))/h0
+     re(5, 4) = -elrad*orbit(4)*(kx*orbit(1) + ky*orbit(3))*(one + beta*orbit(6))/beta/h0**3
+     re(5, 5) = one
+     re(5, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))*(beta**2/h0 - (one + beta*orbit(6))**2/h0**3)/beta**2
+
+     re(6, 6) = one
+  endif
+  ! Second-order terms by derivation of Eqs. (39) in Ref. above, at zero
+  ! te(6,6,6) is assumed to be a zero tensor as input
+  if ((fsec) .and. (nord .ge. 2)) then
+     ! The next three expressions emerge by the second
+     ! derivative of \partial_+ G wrt. x and y at zero, see documentation.
+     ! The additional factor two in the end accounts for the fact
+     ! that the te(6,6,6) tensor and the 2nd derivative are related
+     ! by the usual Taylor-expansion factorials.
+     do k = 0, nord - 2
+         do j = 0, k
+             dxxsigma(k, j) = ((k + one - j)*((k + two - j)*sigma(k + 2, j) + two*(j + one)*sigma(k + 2, j + 1)) + &
+                              (j + one)*(j + two)*sigma(k + 2, j + 2))/4
+             dxysigma(k, j) = (0, 1)*((k + one - j)*(k + two - j)*sigma(k + 2, j) &
+                              - (j + one)*(j + two)*sigma(k + 2, j + 2))/4
+             dyysigma(k, j) = -((k + one - j)*((k + two - j)*sigma(k + 2, j) - two*(j + one)*sigma(k + 2, j + 1)) + &
+                              (j + one)*(j + two)*sigma(k + 2, j + 2))/4
+         enddo
+     enddo
+
+     dxx = 0
+     dxy = 0
+     dyy = 0
+     do k = 0, nord - 2
+         do j = 0, k
+             dxx = dxx + dxxsigma(k, j)*rp**(k - j)*rm**j
+             dxy = dxy + dxysigma(k, j)*rp**(k - j)*rm**j
+             dyy = dyy + dyysigma(k, j)*rp**(k - j)*rm**j
+         enddo
+     enddo
+     dxx = dxx/two
+     dxy = dxy/two
+     dyy = dyy/two
+
+     ! if evaluated at zero, one can use instead:
+     !dxx = elrad/two*(three*g(3, 0) + two*g(3, 1) + g(3, 2))/two
+     !dxy = elrad/two*(0, 1)*(three*g(3, 0) - g(3, 2))/two
+     !dyy = -elrad/two*(three*g(3, 0) - two*g(3, 1) + g(3, 2))/two
+
+     te(1, 1, 2) = elrad*kx*(one/h0 + orbit(2)**2/h0**3)/two
+     te(1, 1, 4) = elrad*kx*orbit(2)*orbit(4)/h0**3/two
+     te(1, 1, 6) = -elrad*kx*orbit(2)/h0**3*(one + beta*orbit(6))/beta/two
+
+     te(1, 2, 1) = te(1, 1, 2)
+     te(1, 2, 2) = elrad*(kx*orbit(1) + ky*orbit(3))*3*orbit(2)/h0**3*(one + orbit(2)**2/h0**2)/two
+     te(1, 2, 3) = elrad*ky*(one/h0 + orbit(2)**2/h0**3)/two
+     te(1, 2, 4) = elrad*(kx*orbit(1) + ky*orbit(3))*(orbit(4)/h0**3 + 3*orbit(2)**2*orbit(4)/h0**5)/two
+     te(1, 2, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))*(one/h0**2 + 3*orbit(2)**2/h0**4)/beta/h0*(one + beta*orbit(6))/two
+
+     te(1, 3, 2) = te(1, 2, 3)
+     te(1, 3, 4) = elrad*ky*orbit(2)*orbit(4)/h0**3/two
+     te(1, 3, 6) = elrad*ky*orbit(2)/beta/h0*(one + beta*orbit(6))/two
+
+     te(1, 4, 1) = te(1, 1, 4)
+     te(1, 4, 2) = te(1, 2, 4)
+     te(1, 4, 3) = te(1, 3, 4)
+     te(1, 4, 4) = elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)*(one/h0**3 + 3*orbit(4)**2/h0**5)/two
+     te(1, 4, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)*orbit(4)*3/h0**5/beta*(one + beta*orbit(6))/two
+
+     te(1, 6, 1) = te(1, 1, 6)
+     te(1, 6, 2) = te(1, 2, 6)
+     te(1, 6, 3) = te(1, 3, 6)
+     te(1, 6, 4) = te(1, 4, 6)
+     te(1, 6, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)/beta/h0**3*(beta - 3/h0/beta**2*(one + orbit(6))**2)/two
+
+     te(2, 1, 1) = real(dxx)   ! cf
+     te(2, 1, 3) = real(dxy)   ! cf
+
+     te(2, 2, 2) = - te(1, 1, 2) ! checked
+     te(2, 2, 4) = -elrad*kx*orbit(2)*orbit(4)/h0**3/two
+     te(2, 2, 6) = elrad*kx*orbit(2)/h0**3/beta*(one + beta*orbit(6))/two
+
+     te(2, 3, 1) = te(2, 1, 3) ! cf
+     te(2, 3, 3) = real(dyy)   ! cf
+
+     te(2, 4, 2) = te(2, 2, 4)
+     te(2, 4, 4) = -elrad*kx*(one/h0 + orbit(4)**2/h0**3)/two ! - te(1, 1, 2) old
+     te(2, 4, 6) = elrad*kx*orbit(4)/h0**3/beta*(one + beta*orbit(6))/two
+     
+     te(2, 6, 2) = te(2, 2, 6)
+     te(2, 6, 4) = te(2, 4, 6)
+     te(2, 6, 6) = elrad*kx*(one/h0 - (one + beta*orbit(6))**2/beta**2/h0**3)/two  ! = te(1, 1, 2)*bp1 old
+
+     te(3, 1, 2) = elrad*kx*orbit(2)*orbit(4)/h0**3/two
+     te(3, 1, 4) = elrad*kx*(one/h0 + orbit(4)**2/h0**3)/two
+     te(3, 1, 6) = -elrad*kx*orbit(4)/h0**3/beta*(one + beta*orbit(6))/two
+
+     te(3, 2, 1) = te(3, 1, 2)
+
+     te(3, 2, 2) = elrad*(kx*orbit(1) + ky*orbit(3))*orbit(4)/h0**3*(one + 3*orbit(2)**2/h0**2)/two
+     te(3, 2, 3) = elrad*ky*orbit(2)*orbit(4)/h0**3/two
+     te(3, 2, 4) = elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)/h0**3*(one + 3*orbit(4)**2/h0**2)/two
+     te(3, 2, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))*orbit(2)*orbit(4)/h0**5/beta*(one + beta*orbit(6))/two
+
+     te(3, 3, 2) = te(3, 2, 3)
+     te(3, 3, 4) = te(1, 2, 3) ! checked
+     te(3, 3, 6) = -elrad*ky*orbit(4)/h0**3/beta*(one + beta*orbit(6))/two
+
+     te(3, 4, 1) = te(3, 1, 4)
+     te(3, 4, 2) = te(3, 2, 4)
+     te(3, 4, 3) = te(3, 3, 4)
+
+     te(3, 4, 4) = elrad*(kx*orbit(1) + ky*orbit(3))*3*orbit(4)/h0**3*(one + orbit(4)**2/h0**2)/two
+     te(3, 4, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))/beta/h0**3*(one + beta*orbit(6))*(one + 3*orbit(4)**2/h0**2)/two
+
+     te(3, 6, 1) = te(3, 1, 6)
+     te(3, 6, 2) = te(3, 2, 6)
+     te(3, 6, 3) = te(3, 3, 6)
+     te(3, 6, 4) = te(3, 4, 6)
+     te(3, 6, 6) = -elrad*(kx*orbit(1) + ky*orbit(3))*orbit(4)/beta/h0**3*(beta - 3/beta/h0**2*(one + beta*orbit(6)))/two
+
+     te(4, 1, 1) = - aimag(dxx)  ! cf
+     te(4, 1, 3) = - aimag(dxy)  ! cf
+
+     te(4, 2, 2) = elrad*ky/h0*(one + orbit(2)**2/h0**2)/two
+     te(4, 2, 4) = elrad*ky*orbit(2)*orbit(4)/h0**3/two
+     te(4, 2, 6) = -elrad*ky*orbit(2)/beta/h0**3*(one + beta*orbit(6))/two
+
+     te(4, 3, 1) = te(4, 1, 3)   ! cf
+     te(4, 3, 3) = - aimag(dyy)  ! cf
+
+     te(4, 4, 2) = te(4, 2, 4)
+     te(4, 4, 4) = -elrad*ky/h0*(one + orbit(4)**2/h0**2)/two
+     te(4, 4, 6) = elrad*ky*orbit(4)/beta/h0**3*(one + beta*orbit(6))/two
+
+     te(4, 6, 2) = te(4, 2, 6)
+     te(4, 6, 4) = te(4, 4, 6)
+     te(4, 6, 6) = elrad*ky/beta/h0*(beta - one/beta/h0**2*(one + beta*orbit(6)))/two
+
+     te(5, 1, 2) = -elrad*kx/beta*(one + beta*orbit(6))*orbit(2)/h0**3/two
+     te(5, 1, 4) = -elrad*kx/beta*(one + beta*orbit(6))*orbit(4)/h0**3/two
+     te(5, 1, 6) = -elrad*kx/beta/h0*(beta - one/beta/h0**2*(one + beta*orbit(6)))/two
+
+     te(5, 2, 1) = te(5, 1, 2)
+     te(5, 2, 2) = -elrad*(kx*orbit(1) + ky*orbit(3))*(one + beta*orbit(6))/beta/h0**3*(one + 3*orbit(2)**2/h0**2)/two
+     te(5, 2, 3) = -elrad*orbit(2)*ky*(one + beta*orbit(6))/beta/h0**3/two
+     te(5, 2, 4) = -elrad*orbit(2)*(kx*orbit(1) + ky*orbit(3))*(one + beta*orbit(6))/beta*3/h0**5*orbit(4)/two
+     te(5, 2, 6) = -elrad*orbit(2)*(kx*orbit(1) + ky*orbit(3))/beta/h0**3*(beta - 3/beta/h0**2*(one + beta*orbit(6))**2)/two
+
+     ! 5, 3 = ky/kx * 5, 1
+     te(5, 3, 2) = te(5, 2, 3)
+     te(5, 3, 4) = -elrad*ky/beta*(one + beta*orbit(6))*orbit(4)/h0**3/two
+     te(5, 3, 6) = -elrad*ky/beta/h0*(beta - one/beta/h0**2*(one + beta*orbit(6)))/two
+
+     te(5, 4, 1) = te(5, 1, 4)
+     te(5, 4, 2) = te(5, 2, 4)
+     te(5, 4, 3) = te(5, 3, 4)
+     te(5, 4, 4) = -elrad*(kx*orbit(1) + ky*orbit(3))*(one + beta*orbit(6))/beta/h0**3*(one + 3*orbit(4)**2/h0**2)/two
+     te(5, 4, 6) = -elrad*orbit(4)*(kx*orbit(1) + ky*orbit(3))/beta/h0**3*(beta - 3/beta/h0**2*(one + beta*orbit(6))**2)/two
+
+     te(5, 6, 1) = te(5, 1, 6)
+     te(5, 6, 2) = te(5, 2, 6)
+     te(5, 6, 3) = te(5, 3, 6)
+     te(5, 6, 4) = te(5, 4, 6)
+     te(5, 6, 6) = elrad*3*(kx*orbit(1) + ky*orbit(3))/beta**2/h0**3*(one + beta*orbit(6))*&
+                   (beta - one/beta/h0**2*(one + beta*orbit(6))**2)/two
   endif
 end SUBROUTINE tmmult_cf
 


### PR DESCRIPTION
Transformation of spatial coordinates in thin-cf approximation added. Furthermore, deltap-offset has been more clearly separated from the orbit(6) coordinate. Need checks.