### PR TITLE
Declare a local variable for the do loop index in subroutine tidy

### DIFF
--- a/src/madx_ptc_twiss.f90
+++ b/src/madx_ptc_twiss.f90
@@ -1464,6 +1464,7 @@ contains
     subroutine tidy()
       ! deallocates all the variables
       implicit none
+      integer i
 
       call kill(tw)
       CALL kill(A_script_probe)


### PR DESCRIPTION
A GCC 11 compile fails since tidy is called from within a loop indexed by i, and then the do loop in tidy modifies that same i through host association. I declared a local i in tidy to fix it.