### PR TITLE
Name of element in survey table + wrong keyword when re-define an element

### DIFF
--- a/src/mad_elem.c
+++ b/src/mad_elem.c
@@ -1085,7 +1085,10 @@ add_to_el_list( /* adds element to alphabetic element list */
           p_node = sequences->sequs[j]->start;
           while (p_node && p_node != sequences->sequs[j]->end)
           {
-            if (p_node->p_elem == ell->elem[pos]) p_node->p_elem = *el;
+            if (p_node->p_elem == ell->elem[pos]) {
+              p_node->p_elem = *el;
+              p_node->base_name = (*el)->base_type->name;
+            }
             p_node = p_node->next;
           }
           if (strcmp((*el)->base_type->name, "rfcavity") == 0 &&

--- a/src/mad_node.c
+++ b/src/mad_node.c
@@ -926,7 +926,6 @@ replace_one(struct node* node, struct element* el)
   strcpy(node->name, compound(el->name, k));
   add_to_node_list(node, 0, edit_sequ->nodes);
   node->p_elem = el;
-
   node->base_name = el->base_type->name;
   //strcpy(node->base_name, el->base_type->name);
   node->length = el->length;

--- a/src/mad_table.c
+++ b/src/mad_table.c
@@ -2128,6 +2128,8 @@ vector_to_table_curr(const char* table, const char* name, const double* vals, co
 
 int 
 name_to_table_curr(const char* table, int* ending){
+  if(*ending==0) return string_to_table_curr(table,"name", current_node->name);
+
   char tmp[strlen(current_node->p_elem->name)+3];
   strcpy(tmp, current_node->p_elem->name);
   if(*ending ==1) strcat(tmp, ".ENT");

--- a/src/mad_table.c
+++ b/src/mad_table.c
@@ -1941,6 +1941,7 @@ string_to_table_row(const char* table, const char* name, const int *row, const c
     myfree("string_to_table_row", tbl->s_cols[col][*row-1]);
 
   mycpy(buf, string);
+
   if (strcmp(buf, "name") == 0)
     tbl->s_cols[col][*row-1] = tmpbuff(current_node->name);
   else if (strcmp(buf, "base_name") == 0)


### PR DESCRIPTION
This PR serves 2 purposes:
1. Restore node name internally table survey. This means internally it is now IP:1 instead of ip1
2. When an element is replaced, the keyword was not updated because the node was never updated. This is now fixed.