### PR TITLE
Fixed buffer overflow issues.

### DIFF
--- a/src/mad_macro.c
+++ b/src/mad_macro.c
@@ -125,7 +125,7 @@ make_macro(char* statement)
   struct macro* m;
   char** toks = tmp_l_array->p;
   int i, n, rs, re, start_2;
-  int len = strlen(statement);
+  int len = strlen(statement)+1;
   while(len >= aux_buff->max) grow_char_array(aux_buff);
   strcpy(aux_buff->c, statement);
   get_bracket_range(aux_buff->c, '{', '}', &rs, &re);

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -99,7 +99,7 @@ SUBROUTINE twiss(rt,disp0,tab_name,sector_tab_name)
   dtbyds  = get_value('probe ','dtbyds ')
   charge  = get_value('probe ','charge ')
   npart   = get_value('probe ','npart ')
-  eig_tol = get_value('twiss ','clorb_tol' )
+  eig_tol = get_value('twiss ','clorb_tol ' )
 
 
   !---- Set fast_error_func flag to use faster error function


### PR DESCRIPTION
Found two buffer overflows:
1. make_macro does a strcpy, but doesn't allocate enough space for the null byte at the end
2. Fortran character arguments to get_value always need an extra space at the end, otherwise the ultimately called mycpy will overrun.