### PR TITLE
Prevent tmfrst from requesting twiss command parameters unless it's being called from twiss

### DIFF
--- a/src/emit.f90
+++ b/src/emit.f90
@@ -1027,5 +1027,5 @@ subroutine getclor(orbit0, rt, tt, error)
   RT  = EYE
   OPT = zero
   eig_tol = 1e-4
-  call tmclor(orbit0, .true., .true., eig_tol, opt, rt, tt, error)
+  call tmclor(orbit0, .true., .true., eig_tol, opt, rt, tt, error,.false.)
 end subroutine getclor

--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -772,6 +772,9 @@ SUBROUTINE tmfrst(orbit0,orbit,fsec,ftrk,rt,tt,eflag,kobs,save,thr_on,from_twiss
   if (from_twiss) then
      istaper = get_value('twiss ','tapering ').ne.zero
      tap_itter = get_value('twiss ','tap_itter ')
+  else
+     istaper = .false.
+     tap_itter = 1
   end if
 
   TT = zero


### PR DESCRIPTION
Fixes #1040, though I haven't checked if the tapering functionality is impaired. Basically added an argument to `tmfrst` (and to `tmclor`) to indicate whether they are being called by twiss or not.