### PR TITLE
In tmrefo, replace get_value from twiss with hardcoded eig_tol value.

### DIFF
--- a/src/twiss.f90
+++ b/src/twiss.f90
@@ -262,7 +262,7 @@ SUBROUTINE tmrefo(kobs,orbit0,orbit,rt)
   dtbyds = get_value('probe ','dtbyds ')
   charge = get_value('probe ','charge ')
   npart  = get_value('probe ','npart ')
-  eig_tol = get_value('twiss ','clorb_tol' )
+  eig_tol = 1d-6
 
   ithr_on = izero
   ORBIT0 = zero


### PR DESCRIPTION
`tmrefo` is not called from `twiss`, so there is no `twiss` to get the parameter from. This leads to a buffer overrun. I hardcoded a value for lack of a better solution. For the applications `tmrefo` is called for (`track`, `dynap`), it probably doesn't even matter if the orbit is stable, as long as the eigenvalues are not near +1.