### PR TITLE
fix gcc warnings

### DIFF
--- a/src/mad_ptc.c
+++ b/src/mad_ptc.c
@@ -1,6 +1,6 @@
 #include "madx.h"
 
-void  makerdtstwisstable(void);
+void makerdtstwisstable(void);
 void printpoly(int*, int );
 
 static void
@@ -1920,23 +1920,20 @@ pro_ptc_track(struct in_cmd* cmd)
 }
 /*_______________________________________________________*/
 
-void printpoly(int p[6], int dim )
+void printpoly(int *p, int dim )
 {
- int i;
+  int i;
 
- printf("f"); /*icase*/
+  printf("f"); /*icase*/
 
- for (i=0; i<dim; i++)
-  {
+  for (i=0; i<dim; i++)
     printf("%1d",p[i]); /*icase*/
-  }
 
- printf("\n");
-
+  printf("\n");
 }
 
 /*_______________________________________________________*/
-void makerdtstwisstable()
+void makerdtstwisstable(void)
 {
   int i;
 

--- a/src/mad_regex.c
+++ b/src/mad_regex.c
@@ -252,7 +252,7 @@ myregend(char* mypat, struct reg_token* start)
 {
   const char *rout_name = "myregend";
   struct reg_token *rp, *aux;
-  if (mypat != NULL) myfree(rout_name, mypat); mypat = NULL;
+  if (mypat != NULL) myfree(rout_name, mypat), mypat = NULL;
   rp = start;
   while (rp != NULL)
   {

--- a/src/mad_twiss.c
+++ b/src/mad_twiss.c
@@ -492,7 +492,7 @@ set_twiss_deltas(struct command* comm)
 {
   char* string;
   int i, k = 0, n = 0;
-  double s, sign = one, ar[3];
+  double s, sign = one, ar[3]={0};
   twiss_deltas->curr = 1;
   twiss_deltas->a[0] = 0;
   string = command_par_string_user("deltap", comm);


### PR DESCRIPTION
Fix gcc 11.2.0 warnings on MacOS 