### PR TITLE
Fix in EMIT's solenoid

### DIFF
--- a/src/emit.f90
+++ b/src/emit.f90
@@ -506,7 +506,7 @@ subroutine emdamp(code, deltap, em1, em2, orb1, orb2, re)
            n    = 3
            twon = six
         case (code_solenoid)  !---- Solenoid
-           sksol = node_value('ks ');
+           sksol = node_value('ks ') / two;
            str   = zero
            n     = 0
            twon  = zero


### PR DESCRIPTION
Fix in the solenoid code in EMIT. The was a missing factor of two, due to the difference between the Wolski definition of solenoid strength and the MAD-X's one.