### PR TITLE
Set element parameters to expressions with el->par := ...

### DIFF
--- a/src/mad_cmdpar.c
+++ b/src/mad_cmdpar.c
@@ -511,6 +511,24 @@ set_command_par_value(const char* parameter, struct command* cmd, double val)
   }
 }
 
+void
+set_command_par_expr(const char* parameter, struct command* cmd, struct expression* expr)
+{
+  struct command_parameter* cp;
+  int i;
+  if ((i = name_list_pos(parameter, cmd->par_names)) > -1)
+  {
+    cp = cmd->par->parameters[i];
+    if (cp->type < 3)
+    {
+      if (cp->expr != NULL) cp->expr = delete_expression(cp->expr);
+      cp->expr = expr;
+      cp->double_value = expression_value(cp->expr,2);
+      cmd->par_names->inform[i] = 1; /* mark as set */
+    }
+  }
+}
+
 struct command_parameter*
 store_comm_par_def(char* toks[], int start, int end)
 {

--- a/src/mad_cmdpar.h
+++ b/src/mad_cmdpar.h
@@ -68,6 +68,8 @@ int     command_par_value2(const char* parameter, const struct command*, double*
 struct double_array* command_par_array(const char* parameter, struct command*);
 int     command_par_vector(const char* parameter, struct command*, double* vector);
 void    set_command_par_value(const char* parameter, struct command*, double val);
+// set_command_par_expr: command will own expression
+void    set_command_par_expr(const char* parameter, struct command*, struct expression *);
 void    store_comm_par_value(const char* parameter, double val, struct command*);
 const char*   alias(char* par_string);
 void    fill_par_var_list(struct el_list*, struct command_parameter*, struct var_list*);

--- a/src/mad_var.c
+++ b/src/mad_var.c
@@ -113,12 +113,21 @@ set_sub_variable(char* comm, char* par, struct in_cmd* cmd)
   for (t_num = start; t_num < cmd->tok_list->curr; t_num++)
     if (*(cmd->tok_list->p[t_num]) == ',') break;
 
+  el = find_element(comm, element_list);
   exp_type = loc_expr(cmd->tok_list->p, t_num, start, &end);
 
   if (exp_type == 1) /* literal constant */
     val = simple_double(cmd->tok_list->p, start, end);
-  else if (polish_expr(end + 1 - start, &cmd->tok_list->p[start]) == 0)
-    val = polish_value(deco, join(&cmd->tok_list->p[start], end + 1 - start));
+  else if (polish_expr(end + 1 - start, &cmd->tok_list->p[start]) == 0) {
+    if (cmd->sub_type == 13 && el != NULL) {
+      set_command_par_expr(par, el->def,
+			   new_expression(join(&cmd->tok_list->p[start], end + 1 - start), deco) );
+      current_beam = keep_beam;
+      return;
+    }
+    else
+      val = polish_value(deco, join(&cmd->tok_list->p[start], end + 1 - start));
+  }
 
   if (strncmp(comm, "beam", 4) == 0) {
     command = current_beam = find_command("default_beam", beam_list);
@@ -128,7 +137,7 @@ set_sub_variable(char* comm, char* par, struct in_cmd* cmd)
     }
     set_command_par_value(par, current_beam, val);
   }
-  else if ((el = find_element(comm, element_list)) != NULL)
+  else if (el != NULL)
     set_command_par_value(par, el->def, val);
   else if ((command = find_command(comm, stored_commands)) != NULL)
     set_command_par_value(par, command, val);


### PR DESCRIPTION
For an element `el`, if you try to assign an expression to a parameter via a separate assignment statement, like
```el->par := expr;```
MAD-X will instead assign the current value of the `expr` to the parameter `par`, rather than the expression itself. This patch will cause the expression `expr` to be assigned instead. As written, it only works for element parameters and for assignments in that form (e.g., not prefixed with `real`, etc.).