### PR TITLE
Fix potential buffer overrun when node_name calls stoupper

### DIFF
--- a/src/mad_node.c
+++ b/src/mad_node.c
@@ -696,8 +696,10 @@ node_name(char* name, int* l)
   /* returns current node name in Fortran format */
   /* l is max. allowed length in name */
 {
+  int i;
   strfcpy(name, current_node->name, *l);
-  stoupper(name);
+  for (i=0 ; i < *l ; ++i)
+    name[i] = toupper(name[i]);
 }
 void
 node_name_f_lower(char* name, int* l)


### PR DESCRIPTION
name is a Fortran string and is not null terminated.
stoupper searches for the null termination.
Replace stoupper call by running toupper over the length of the Fortran string.