### PR TITLE
Ensure that exact_model is set before zero_key is called

### DIFF
--- a/src/madx_ptc_module.f90
+++ b/src/madx_ptc_module.f90
@@ -564,6 +564,14 @@ CONTAINS
 
     ord_max = -1
 
+    exact1=node_value("exact ")
+
+    if(exact1.eq.0.or.exact1.eq.1) then
+       EXACT_MODEL = exact1 .ne. 0
+    else
+       EXACT_MODEL = exact0
+    endif
+
     call zero_key(key)
 
     !j=j+1
@@ -615,14 +623,6 @@ CONTAINS
        metd = method1
     else
        metd = method0
-    endif
-
-    exact1=node_value("exact ")
-
-    if(exact1.eq.0.or.exact1.eq.1) then
-       EXACT_MODEL = exact1 .ne. 0
-    else
-       EXACT_MODEL = exact0
     endif
 
     !special node keys


### PR DESCRIPTION
zero_key(key) sets key%exact equal to the value of exact_model
In the previous code, zero_key was called before exact_model was set,
and so key%exact was set based on node_value("exact ") of the previous node.
So, move the code to set exact_model to before zero_key is called.

Fixes #1110 