### PR TITLE
Give TRANSLATION a default for EXACT to take EXACT from PTC_CREATE_LAYOUT

### DIFF
--- a/src/mad_dict.c
+++ b/src/mad_dict.c
@@ -3005,6 +3005,7 @@ const char *const_element_def =
 "kmin     = [r, 0], "
 "calib    = [r, 0], "
 "dx     = [r, 0], dy    = [r, 0], ds    = [r, 0], "
+"exact           = [i, -1, 1], "
 "comments = [s, none, none]; "
 " "
 "crabcavity: element none 0 37 "


### PR DESCRIPTION
This matches the behavior of all other elements
Should only matter for nonzero DS

Note: this does _not_ fix #1110; the example would work, but a simple change to the example by adding `exact=0` to the `translation` would trigger that bug.