### PR TITLE
Increase tolerance in test-survey-3. Remove relative tolerance.

### DIFF
--- a/tests/test-survey-3/survey_chicane_patch.tfs.cfg
+++ b/tests/test-survey-3/survey_chicane_patch.tfs.cfg
@@ -1,2 +1,2 @@
 1-7     *     skip         # head
-*       *     any abs=1e-20 rel=1e-10
+*       *     any abs=3.5e-15

--- a/tests/test-survey-3/survey_chicane_sbend.tfs.cfg
+++ b/tests/test-survey-3/survey_chicane_sbend.tfs.cfg
@@ -1,2 +1,2 @@
 1-7     *     skip         # head
-*       *     any abs=1e-20 rel=1e-10
+*       *     any abs=3.5e-15

--- a/tests/test-survey-3/survey_chicane_thin.tfs.cfg
+++ b/tests/test-survey-3/survey_chicane_thin.tfs.cfg
@@ -1,2 +1,2 @@
 1-7     *     skip         # head
-*       *     any abs=1e-20 rel=1e-10
+*       *     any abs=3.5e-15

--- a/tests/test-survey-3/survey_chicane_thinpatch.tfs.cfg
+++ b/tests/test-survey-3/survey_chicane_thinpatch.tfs.cfg
@@ -1,2 +1,2 @@
 1-7     *     skip         # head
-*       *     any abs=1e-20 rel=1e-10
+*       *     any abs=3.5e-15


### PR DESCRIPTION
Differences showed up when testing with -O0.
Relative tolerance should be eliminated since we're checking values near zero.