### PR TITLE
Flag to throw fatal error when missing file in interactive mode.

### DIFF
--- a/doc/latexuguide/control.tex
+++ b/doc/latexuguide/control.tex
@@ -151,6 +151,7 @@ they are set to \texttt{TRUE} are listed in table \ref{table:options}. Note that
     \hline
     \texttt{TELL}      & false & prints the current value of all options \\
     \texttt{RESET}     & false & resets all options to their defaults \\
+    \texttt{MISSING\_FILE\_FATAL}  & false & missing a file triggers a fatal fault. This flag ONLY impacts the INTERACTIVE mode.  \\
     \hline
     \texttt{NO\_FATAL\_STOP} & false & Prevents madx from stopping in case of a fatal error \\
     &       & \textbf{Use at your own risk !} \\

--- a/src/mad_dict.c
+++ b/src/mad_dict.c
@@ -312,6 +312,7 @@ const char *const_command_def =
 "update_from_parent = [l, false, true], "
 "keep_exp_move      = [l, false, true], "
 "thin_cf            = [l, false, true], "
+"missing_file_fatal = [l, false, true], "
 "fdstep = [r, 0], " /* ld 07.2020, finite difference step for JACOBIAN and LMDIF */
   /* BB and SPCH related options */
 "bborbit          = [l, false, true], " /* frs */

--- a/src/mad_stream.c
+++ b/src/mad_stream.c
@@ -53,7 +53,8 @@ down_unit(char* file_name)
   
   if ((new = fopen(file_name, "r")) == NULL)
   {
-    if (interactive) warning("cannot open input file:", file_name);
+    int fatal_missing = get_option("missing_file_fatal"); // only for the interactive mode, in other cases always fatal. 
+    if (interactive && fatal_missing == 0)  warning("cannot open input file:", file_name);
     else             fatal_error("cannot open input file:", file_name);
     return 0;
   }


### PR DESCRIPTION
A missing file caused a problem in the upload of an optics. This was not spotted since JMAD runs in interactive mode and calling a missing file only triggers a warning. This PR adds a flag to make this fatal also in interactive mode. The default behaviour is as in the past. 