### PR TITLE
Fix in Dimension of z Parameter

### DIFF
--- a/src/trrun.f90
+++ b/src/trrun.f90
@@ -5905,7 +5905,7 @@ end subroutine wzsub
     logical, intent(In) :: dynap
     integer :: i, j
 
-    double precision, intent(IN) :: orbit0(6), z(6,N_macro_surv)
+    double precision, intent(IN) :: orbit0(6), z(6,*)
    
    !if (bb_sxy_update) !hrr Dec 2021 checkpoint_restart must not depend on bb_sxy_update   
    if (.not. dynap) then 


### PR DESCRIPTION
# Issue
After compiling Mad-X in Debug mode, it crashes when running tracking because of an access to the parameter `z` in `BB_Write` in `trrun.f90`.

# Possible Cause
`z` is declared with dimensions `(6,0)` since `N_macro_surv` is not set yet (the corresponding branch in `BB_Init` isn't taken.

When running in Release mode, the check for the declared size of `z` seems to be optimised away and the actual size of the value passed to `BB_Write` (presumably `(6, jmax)`) is large enough to not trigger a crash.

# Proposed Solution
Following the example of various other functions, changing the declaration to `z(6,*)` seems to fix this issue.

# Notes and Open Questions
- I open this PR as draft, since I am not yet entirely familiar with the coding conventions
- `z` is accessed in multiple functions under the assumption that its dimensions are `(6, jmax)`. In this regard, would changing the declaration to `z(6,jmax)` be an option?
- There is no check of the _actual_ size of `z` before accessing it. This feels a bit unsafe, Is a size of `(6, jmax)` guaranteed?