### PR TITLE
Github Action Fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -112,7 +112,7 @@ jobs:
   build:
     # Configure, build, and test with few settings. This is slow, so shouldn't
     # add too many combinations here.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       MADXDIR: ${{ github.workspace }}/dist
     strategy:

--- a/.github/workflows/cpymad.yml
+++ b/.github/workflows/cpymad.yml
@@ -94,7 +94,7 @@ jobs:
           repository: hibtc/cpymad
           ref: ${{ matrix.version }}
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          # - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04
         buildtool:

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: bin-manylinux${{ matrix.manylinux }}-${{ matrix.buildtool }}
           path: bin

--- a/libs/ptc/src/Sh_def_kind.f90
+++ b/libs/ptc/src/Sh_def_kind.f90
@@ -167,7 +167,7 @@ MODULE S_DEF_KIND
 private rk2abellr,rk4abellr,rk6abellr,rk2abellp,rk4abellp,rk6abellp,get_z_abr,get_z_abp
 private fx_newcr,fx_newcp,fx_newc,feval_CAV_impr,feval_CAV_imp,rk1bmad_cav_impr
 integer :: tot_t=1
-logical :: old_thick_bend = .false.
+logical :: old_thick_bend = .true.
 !logical :: old_electric = .false.
 PRIVATE get_fieldR,get_fieldp
 PRIVATE get_Bfield_fringeR,get_Bfield_fringeP !,get_Bfield_fringe

--- a/tests/test-ptc-normal-5D-beambeam/leir.ptc.nonlin.cfg
+++ b/tests/test-ptc-normal-5D-beambeam/leir.ptc.nonlin.cfg
@@ -1,8 +1,6 @@
 4-6      *     skip         # date,version
-*        *     any abs=5 rel=1e-5
-113 1 abs=1e-6
-143 1 abs=1e-6
-299 1 abs=1e-6  # high order RDT
-338 * abs=1e-6  # high order RDT
-
-
+*        *     any abs=5e-6 rel=1e-7
+113 1 abs=1e-11
+143 1 abs=1e-11
+299 1 abs=1e-7  # high order RDT
+338 * abs=1e-7  # high order RDT

--- a/tests/test-ptc-twiss-old5/test-ptc-twiss-old5.cfg
+++ b/tests/test-ptc-twiss-old5/test-ptc-twiss-old5.cfg
@@ -3,5 +3,7 @@
 206        2     rel=5e-9  # betas min maxes
 206        4     rel=5e-9  # betas min maxes
 209        2     rel=5e-9  # betas min maxes
+209        4     rel=5e-9  # betas min maxes
 215        2     rel=5e-9  # betas min maxes
+218        2     rel=5e-9  # betas min maxes
 


### PR DESCRIPTION
Fixes
- Remove _all_ uses of outdated ubuntu-18.04, which reached end of life on May 31, 2023
- Update the following actions due to Node 12 to Node 16 change
  - Setup python v2 -> v4
  -  download-artifact v2 -> v3
-  Update `old_thick_bend` to `true` 
- Revert leir.ptc.nonlin.cfg changes forcing test to not run (overall, just reduce the tolerances)
- Add more beta min max tolerances

After all of these fixes, all of the actions will pass, without warnings. Also, the actions will take somewhere around 20 minutes, instead of a day, since the actions do not hang waiting for an Ubuntu-18.04 machine.