### PR TITLE
Action Fix 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -ex
+          sudo apt update
           sudo apt-get install -qy \
             texlive-latex-base \
             texlive-latex-extra \


### PR DESCRIPTION
Build will fail because of 404 error, so we need to update the repository data before doing the install