### PR TITLE
Evaluates the Fix add2expression directly.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,9 @@ MAD-X release 5.09.02 (2024.??.??)
     * Fixed an issue where the IBS table would only be created if the `FILE="STRING"` part of the command was provided, instead of always as documented.
     * Added an export of the `ibs.coulog` and `ibs.const` variables after calling the IBS command (see user guide).
     * Documented the IBS code.
+* Add2expr
+  * [PR1 1211] (https://github.com/MethodicalAcceleratorDesign/MAD-X/pull/1211) Evaluates the expression when defined.
+    * Previously it was possible to add as syntax error in the expression and this was only detected when the expression was evaluated. This PR fixes that. 
 
 
 MAD-X release 5.09.01 (2023.12.04)

--- a/src/mad_cmd.c
+++ b/src/mad_cmd.c
@@ -763,57 +763,45 @@ add_to_command_list_list(char* label, struct command_list* cl, struct command_li
 void exec_add_expression(struct in_cmd* cmd){
   char* varname = command_par_string_user("var", cmd->clone);
   char* expchar = command_par_string_user("expr", cmd->clone);
-  if(expchar==NULL){
+  //const char whitespace[] = " \f\n\r\t\v";
+  struct variable* var;
+  char in_string_tmp[100];
+  char tmp_var_expr[50
+    ];
+
+  if (expchar==NULL){
     warning("Need to add an expression for: ", varname);
     return;
-  }
-  struct variable* var;
-  struct expression* expr1, *expr2; 
-  struct expression* exprcomb;
+  } 
+  //create an input string starting with the varname
+  strcpy(in_string_tmp, varname);
+  strcat(in_string_tmp, ":= ");
+  
+  //Adds the varialbe expression or valube in case it is not an expression
   if ((var = find_variable(varname, variable_list)) == NULL) {
-      var = new_variable(varname, 0, 1, 2, NULL, NULL);
-      add_to_var_list(var, variable_list, 1);
+    strcpy(tmp_var_expr, " ");
+  }
+  else if(var->type==1 || (var->expr==NULL)) {
+      sprintf(tmp_var_expr, "%.16f", var->value);
+  }
+  else {
+    strcpy(tmp_var_expr, var->expr->string);
+  }
+  strcat(in_string_tmp, tmp_var_expr);
+  
+  // Fine to only check the first because the string is already stripped. 
+  if(expchar[0]=='+' || expchar[0]=='-') {
+    strcat(in_string_tmp, " ");
+  }
+  else { //If not a + or minus in the beginning then we add a +
+    strcat(in_string_tmp, " + ");
   }
 
-  if ((var = find_variable(varname, variable_list)) != NULL){
-      
-    if(var->type==2){
-      if(var->expr==NULL){
-
-        char *result = malloc(100 * sizeof(char));
-        sprintf(result, "%.16f", var->value);
-        expr1 = new_expression(result,NULL);
-        free(result);
-        var->expr = mymalloc("add expression", sizeof *var->expr);
-      }
-      else {
-        expr1 = clone_expression(var->expr);
-      }
-      expr2 = new_expression(expchar,NULL);
-      exprcomb = compound_expr(expr1, expression_value(expr1, 2), "+", expr2, expression_value(expr2, 2), 0);
-      memcpy (var->expr, exprcomb, sizeof(*exprcomb));
-    }
-    else if (var->type==1){
-
-      char *result = malloc(100 * sizeof(char));
-      sprintf(result, "%.16f", var->value);
-      expr1 = new_expression(result,NULL);
-      free(result);
-      
-      expr2 = new_expression(expchar,NULL);
-      exprcomb = compound_expr(expr1, expression_value(expr1, 2), "+", expr2, expression_value(expr2, 2),0);
-      var->expr = mymalloc("add expression", sizeof *var->expr);
-      memcpy (var->expr, exprcomb, sizeof(*exprcomb));
-      var->type=2; //makes it an expression
-    }
-    else{
-      warning("Variable has to be declared as defered expression or as an assignment: ", varname);
-    }
-
-  }
-  else{
-    warning("The variable that trying to add expression to is not existing: ", varname);
-  }
+  strcat(in_string_tmp, expchar);    
+  
+  strcat(in_string_tmp, ";");
+  pro_input(in_string_tmp);
+  return;
 }
 
 void

--- a/src/mad_var.c
+++ b/src/mad_var.c
@@ -351,7 +351,7 @@ enter_variable(struct in_cmd* cmd) /* stores variable contained in cmd */
   n = name = permbuff(cmd->tok_list->p[name_pos]);
   if (exp_type == 0)
   {
-    warning("illegal expression set to 0 in:",
+    warning("illegal expression, expression NOT updated for the following :",
             join_b(cmd->tok_list->p, cmd->tok_list->curr));
   }
   else

--- a/tests/test-addexpression/test-addexpression.ref
+++ b/tests/test-addexpression/test-addexpression.ref
@@ -1,9 +1,9 @@
 
   ++++++++++++++++++++++++++++++++++++++++++++
-  +     MAD-X 5.07.00  (64 bit, Linux)       +
+  +     MAD-X 5.09.01  (64 bit, Linux)       +
   + Support: mad@cern.ch, http://cern.ch/mad +
-  + Release   date: 2021.05.03               +
-  + Execution date: 2021.12.10 13:04:55      +
+  + Release   date: 2023.12.04               +
+  + Execution date: 2024.01.22 17:05:50      +
   ++++++++++++++++++++++++++++++++++++++++++++
 	
 
@@ -17,10 +17,13 @@ add2expr, var = x, expr=-a;
 
 add2expr, var = x, expr=b;
 
+++++++ info: x redefined
 add2expr, var = y, expr=b;
 
+++++++ info: y redefined
 add2expr, var = z, expr=c;
 
+++++++ info: z redefined
 
 
 z1=100; ! Doesn't change because not a defered expression
@@ -37,13 +40,13 @@ c=4;
 
 show, x;
 
-x                  := 0.0000000000000000 - a + b  ;
+x                  := -a+b               ;
 show, y;
 
-y                  := 2.0000000000000000 + b  ;
+y                  := 2.0000000000000000+b ;
 show, z;
 
-z                  := 0.0000000000000000 + c  ;
+z                  := 0.0000000000000000+c ;
 
 
 value, x;


### PR DESCRIPTION
This PR fixes the issue in #1211. The problem is when there is an error in the add2expression this only manifest later because it is not shown. This is changed so now it is evaluated exactly in the same way as any other expression that is input. 

