### PR TITLE
slice volt

### DIFF
--- a/src/mad_mkthin.cpp
+++ b/src/mad_mkthin.cpp
@@ -2440,7 +2440,7 @@ void SeqElList::slice_node_default() // slice/translate and add slices to sliced
 
 void SeqElList::slice_attributes_to_slice(command* cmd,const element* thick_elem)
 { // looks for attributes like kick that need slicing, modify them in cmd used to construct the sliced element
-  const std::vector<std::string> attributes_to_slice = { "kick", "hkick", "vkick", "chkick", "cvkick", "current"};
+  const std::vector<std::string> attributes_to_slice = { "kick", "hkick", "vkick", "chkick", "cvkick", "current","volt"};
   ElmAttr theElmAttr(thick_elem);
   std::vector<std::string> active_par_to_be_used=theElmAttr.get_list_of_active_attributes();
   for(unsigned i=0;i<active_par_to_be_used.size();++i)


### PR DESCRIPTION
```
ss: sequence, l=4;
ff: rfcavity, at=2,l=2,volt=3;
endsequence;
beam;
use,sequence=ss;

select,flag=makethin, slice=4, thick=true;
makethin, sequence=ss;
save,sequence=ss,file=ss.madx;
```

returns now

```
ff..1: rfcavity,volt:= 0.75;
ff..2: rfcavity,volt:= 0.75;
ff: marker;
ff..3: rfcavity,volt:= 0.75;
ff..4: rfcavity,volt:= 0.75;
ss: sequence, l = 4;
ff..1, at = ( ( 2 ) + ( 0 ) ) + ( 0 - 1 ) ;
ff..2, at = ( ( 2 ) + ( 0 ) ) + ( 0 - 0.33333333333333 ) ;
ff, at = ( 2 ) + ( 0 ) ;
ff..3, at = ( ( 2 ) + ( 0 ) ) + ( 0.33333333333333 ) ;
ff..4, at = ( ( 2 ) + ( 0 ) ) + ( 1 ) ;
endsequence;
```