### PR TITLE
Changes to build on up-to-date msys2

### DIFF
--- a/cmake/compilers/setupGNU.cmake
+++ b/cmake/compilers/setupGNU.cmake
@@ -42,8 +42,4 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
-    if(WIN32)
-      # MinGW automatically adds -ansi, so c++ code does not compile without this flag as well..
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -U__STRICT_ANSI__")
-    endif()
 endif()

--- a/src/mad_port.h
+++ b/src/mad_port.h
@@ -9,6 +9,8 @@
 #ifdef __MINGW32__
 // problem with unistd compliance on Cygwin
 typedef long long off64_t;
+// For Windows _mkdir
+#include <direct.h>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
I needed to make these two changes to make mad-x build on an up-to-date msys2. I was building with CMake, under the ucrt64 environment.