### PR TITLE
name_to_table_curr: fix temp buffer size calc

### DIFF
--- a/src/mad_table.c
+++ b/src/mad_table.c
@@ -2132,7 +2132,7 @@ int
 name_to_table_curr(const char* table, int* ending){
   if(*ending==0) return string_to_table_curr(table,"name", current_node->name);
 
-  char tmp[strlen(current_node->p_elem->name)+3];
+  char tmp[strlen(current_node->p_elem->name)+5];
   strcpy(tmp, current_node->p_elem->name);
   if(*ending ==1) strcat(tmp, ".ENT");
   if(*ending ==2) strcat(tmp, ".EXI");


### PR DESCRIPTION
Triggered address sanitizer error.
Calculation is obviously wrong.
Eliminated 11 test failures in test suite with sanitizer on.